### PR TITLE
Adds the civilian ID to the civ details

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -333,6 +333,11 @@ footer {
     box-shadow: none;
 }
 
+.form-label {
+    padding: 6px 0px 0px 0px;
+    font-size: 14px;
+}
+
 textarea {
     resize: none;
 }

--- a/views/civ-dashboard.html
+++ b/views/civ-dashboard.html
@@ -309,6 +309,13 @@
             <hr style="width: 88%;max-width: 100rem;">
 
             <div class="form-group">
+              <label class="col-md-4 control-label" for="civilianIDView">ID #:</label>
+              <div class="col-md-4">
+                <label id="civilianIDView" class="form-label"></label>
+              </div>
+            </div>
+
+            <div class="form-group">
                 <label class="col-md-4 control-label" for="firstNameView">First Name:</label>
                 <div class="col-md-4">
                   <input id="firstName" name="firstName" type="text" placeholder="First Name" class="form-control input-md" data-trigger="first-name-popover" data-content="* First name cannot contain spaces." required="">
@@ -477,6 +484,7 @@
     
     $('#civilianID').val(myVar[index]._id)
     $('#firstNameView').text(firstName)
+    $('#civilianIDView').text(myVar[index]._id)
     $('#firstName').text(firstName)
     $('#lastNameView').text(lastName)
     $('#licenseStatusView').val(licenseStatus)

--- a/views/release-log.html
+++ b/views/release-log.html
@@ -76,6 +76,21 @@
           <div class="grid grid--cover-links">
 
               <div class="grid__cell grid__cell--medium">
+                <div class="grid__cell-content">
+                  <h2>Patch 0.8.2</h2>
+                  <div class="platform platform--ps4">Mobile</div>
+                  <div class="platform platform--pc">PC</div>
+                  <p><strong>Patch 0.8.2 adds the civilian ID to the civ details.</strong>
+                      <br/>
+                      <br/>- Quick addition of the civilian ID to the details when clicking on a persona.
+                      <br/>- Allows users to view the associated ID when clicking on their civilian.
+                  </p>
+                  <p>For more info on this patch view our release log: <a
+                      href="https://github.com/Linesmerrill/police-cad/releases/tag/v0.8.2">Patch v0.8.2</a></p>
+                </div>
+              </div>
+
+              <div class="grid__cell grid__cell--medium">
                   <div class="grid__cell-content">
                     <h2>Patch 0.8.1</h2>
                     <div class="platform platform--ps4">Mobile</div>


### PR DESCRIPTION
- Quick addition of the civilian ID to the details when clicking on a persona.
- Allows users to view the associated ID when clicking on their civilian.