### PR TITLE
add new button for signal 100 for dispatch

### DIFF
--- a/app/models/community.js
+++ b/app/models/community.js
@@ -6,6 +6,7 @@ var communitySchema = mongoose.Schema({
     ownerID: String,
     code: String,
     activePanics: Map,
+    activeSignal100: Boolean,
     createdAt: Date,
     updatedAt: Date
   }

--- a/views/dispatch-dashboard.ejs
+++ b/views/dispatch-dashboard.ejs
@@ -39,11 +39,16 @@
 <body>
   
   <nav id="topNav" class="navbar navbar-default navbar-fixed-top">
-    <!-- <div class="panel panel-danger">
-      <div class="panel-heading">
-        <h3 class="panel-title text-align-center">🚨🚨🚨   Signal 100 In Effect!   🚨🚨🚨</h3>
+    <a data-toggle="modal" href="#signal100DetailModal">
+      <div id="signal-100-banner" class="panel panel-danger hide">
+        <div class="panel-heading text-align-center">
+          <span class="panel-title text-align-center">🚨🚨🚨   Signal 100 In Effect!   🚨🚨🚨</span>
+          <button type="button" class="close" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
       </div>
-    </div> -->
+    </a>
     <div class="container-fluid">
       <div class="navbar-header">
         <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-navbar">
@@ -107,6 +112,7 @@
         <button type="button" data-toggle="modal" href="#" onclick="$('#nameDatabaseModal').modal({'backdrop': 'static'});" class="btn btn-primary btn-lg margin-top-2">Name Database</button>
           <button type="button" data-toggle="modal" href="#plateDatabaseModal" class="btn btn-primary btn-lg margin-top-2">Plate Database</button>
           <button type="button" data-toggle="modal" href="#firearmDatabaseModal" class="btn btn-primary btn-lg margin-top-2">Firearm Database</button>
+          <button type="button" class="btn btn-primary btn-lg margin-top-2" onclick="signal100()">Signal 100</button>
         </div>
       </div>
     </div>
@@ -1526,6 +1532,22 @@
       </div>
     </div>
   </div>
+
+  <div id="signal100DetailModal" class="modal" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <span class="modal-title" style="font-size: 18px;">Clear Signal 100</span>
+          <button class="btn btn-primary btn-md float-right" type="button" data-dismiss="modal" aria-hidden="true">X</button>
+        </div>
+        <div class="modal-footer text-align-center">
+          <button type="button" class="btn btn-danger" data-dismiss="modal" onclick="clearSignal100()">Clear</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  
   <% include 10-codes %> 
   <% include notepad %>
 </body>
@@ -1564,9 +1586,17 @@
       }
     })
 
-    socket.on('load_panic_status_update', (map, origReq) => {
+    socket.on('load_panic_status_update', (map, signal100Resp, origReq) => {
       var myUser = <%- JSON.stringify(user) %>;
       if (myUser.user.activeCommunity == origReq.activeCommunity) {
+        //load the signal 100 status to the page
+        if (signal100Resp) {
+          $('#signal-100-banner').removeClass('hide').addClass('show')
+        } else {
+          $('#signal-100-banner').removeClass('show').addClass('hide')
+        }
+
+        //load the panic status items
         $('#panic-placeholder-socket').empty();
         $('#panic-placeholder').append(
           '<div id="panic-placeholder-socket"></div>'
@@ -1625,6 +1655,25 @@
       $('#'+res.userID+'-panic-row').remove().fadeOut(1, function() {
         $(this).remove();
       })
+    })
+
+    socket.on('signal_100_button_updated', (origReq) => {
+      var myUser = <%- JSON.stringify(user) %>;
+      if (myUser.user.activeCommunity == origReq.activeCommunity) {
+        if ($('#panic-button-check-sound').prop('checked')) {
+          var audioElement = document.createElement('audio');
+          audioElement.setAttribute('src', 'http://www.soundjay.com/button/sounds/beep-07.mp3');
+          audioElement.play();
+        }
+        $('#signal-100-banner').removeClass('hide').addClass('show')
+      }
+    })
+
+    socket.on('clear_signal_100_updated', activeCommunity => {
+      var myUser = <%- JSON.stringify(user) %>;
+      if (myUser.user.activeCommunity == activeCommunity) {
+        $('#signal-100-banner').removeClass('show').addClass('hide')
+      }
     })
 
     socket.on('updated_bolo', res => {
@@ -2065,6 +2114,13 @@ function searchFirearm() {
     $('#boloDetailModal').modal('hide')
   })
 
+  function clearSignal100() {
+    var socket = io();
+    myUser = <%- JSON.stringify(user) %>
+    socket.emit('clear_signal_100', myUser.user.activeCommunity)
+    $('#signal-100-banner').removeClass('show').addClass('hide')
+  }
+
   $('#createBolo').one('click', function() {
     // location.assign('/dispatch-dashboard')
     var socket = io();
@@ -2193,5 +2249,27 @@ function searchFirearm() {
     $(this).hide();
   });
     })
+  }
+
+  function signal100() {
+    //if it is already showing we don't want to show it again (there can only be 1 active
+    // signal 100 per community)
+    if (!$('#signal-100-banner').hasClass('show')) {
+    var myUser = <%- JSON.stringify(user) %>;
+    var socket = io();
+    myReq = {
+      userID: myUser._id,
+      userUsername: myUser.user.username,
+      activeCommunity: myUser.user.activeCommunity
+    }
+    if ($('#panic-button-check-sound').prop('checked')) {
+      var audioElement = document.createElement('audio');
+      audioElement.setAttribute('src', 'http://www.soundjay.com/button/sounds/beep-07.mp3');
+      audioElement.play();
+    }
+    
+    socket.emit('signal_100_button_update', myReq)
+  }
+    
   }
 </script>

--- a/views/footer.ejs
+++ b/views/footer.ejs
@@ -44,11 +44,12 @@
         <br />
         <span class="pull-right text-muted small"><a href="/">Lines Police CAD</a> ©2020 TLPS LLC</span>
     </div>
-    <script>
+    <div class="powr-popup-notification" id="75da3ab7_1598195583"></div><script src="https://www.powr.io/powr.js?platform=html"></script>
+    <!-- <script>
         var beamer_config = {
             product_id : "HEmENJwN25244" //DO NOT CHANGE: This is your product code on Beamer
         };
     </script>
-    <script type="text/javascript" src="https://app.getbeamer.com/js/beamer-embed.js" defer="defer"></script>
+    <script type="text/javascript" src="https://app.getbeamer.com/js/beamer-embed.js" defer="defer"></script> -->
                         
 </footer>

--- a/views/footer.ejs
+++ b/views/footer.ejs
@@ -45,11 +45,4 @@
         <span class="pull-right text-muted small"><a href="/">Lines Police CAD</a> ©2020 TLPS LLC</span>
     </div>
     <div class="powr-popup-notification" id="75da3ab7_1598195583"></div><script src="https://www.powr.io/powr.js?platform=html"></script>
-    <!-- <script>
-        var beamer_config = {
-            product_id : "HEmENJwN25244" //DO NOT CHANGE: This is your product code on Beamer
-        };
-    </script>
-    <script type="text/javascript" src="https://app.getbeamer.com/js/beamer-embed.js" defer="defer"></script> -->
-                        
 </footer>

--- a/views/police-dashboard.ejs
+++ b/views/police-dashboard.ejs
@@ -36,6 +36,11 @@
 
 <body>
   <nav id="topNav" class="navbar navbar-default navbar-fixed-top">
+    <div id="signal-100-banner" class="panel panel-danger hide">
+      <div class="panel-heading">
+        <h3 class="panel-title text-align-center">🚨🚨🚨   Signal 100 In Effect!   🚨🚨🚨</h3>
+      </div>
+    </div>
     <div class="container-fluid">
       <div class="navbar-header">
         <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-navbar">
@@ -1487,9 +1492,17 @@
       }
     })
 
-    socket.on('load_panic_status_update', (map, origReq) => {
+    socket.on('load_panic_status_update', (map, signal100Resp, origReq) => {
       var myUser = <%- JSON.stringify(user) %>;
       if (myUser.user.activeCommunity == origReq.activeCommunity) {
+        //load the signal 100 status to the page
+        if (signal100Resp) {
+          $('#signal-100-banner').removeClass('hide').addClass('show')
+        } else {
+          $('#signal-100-banner').removeClass('show').addClass('hide')
+        }
+        
+        //load the panic status items
         $('#panic-placeholder-socket').empty();
         $('#panic-placeholder').append(
           '<div id="panic-placeholder-socket"></div>'
@@ -1548,6 +1561,25 @@
       $('#'+res.userID+'-panic-row').remove().fadeOut(1, function() {
         $(this).remove();
       })
+    })
+
+    socket.on('signal_100_button_updated', (origReq) => {
+      var myUser = <%- JSON.stringify(user) %>;
+      if (myUser.user.activeCommunity == origReq.activeCommunity) {
+        if ($('#panic-button-check-sound').prop('checked')) {
+          var audioElement = document.createElement('audio');
+          audioElement.setAttribute('src', 'http://www.soundjay.com/button/sounds/beep-07.mp3');
+          audioElement.play();
+        }
+        $('#signal-100-banner').removeClass('hide').addClass('show')
+      }
+    })
+
+    socket.on('clear_signal_100_updated', activeCommunity => {
+      var myUser = <%- JSON.stringify(user) %>;
+      if (myUser.user.activeCommunity == activeCommunity) {
+        $('#signal-100-banner').removeClass('show').addClass('hide')
+      }
     })
 
     socket.on('updated_bolo', res => {

--- a/views/release-log.ejs
+++ b/views/release-log.ejs
@@ -67,6 +67,34 @@
         <div class="grid grid--cover-links">
           <div class="grid grid--cover-links">
 
+            <div id="Release-2.7.0" class="grid__cell grid__cell--medium">
+              <div class="grid__cell-content">
+                <h2>Release 2.7.0</h2>
+                <div class="platform platform--ps4">Mobile</div>
+                <div class="platform platform--pc">PC</div>
+                <h3>Release 2.7.0 Adds a Signal 100 Button for Dispatch</h3>
+                <div class="row">
+                  <div
+                    class="col-xs-10 col-sm-9 col-md-9 col-lg-6 col-xs-offset-1 col-sm-offset-2 col-md-offset-3 col-lg-offset-3  text-align-left">
+                    <p>
+                      <br />
+                      <strong><u>New:</u></strong>
+                      <br />- Adds a new Signal 100 Button for Dispatch
+                      <br />- Will show up across all police and dispatch pages in your community at the top
+                      <br />- Plays sound when signal 100 button is pressed <strong>(mobile functionality is limited due to Safari and Chrome restrictions)</strong>
+                      <br />- Use same setting as panic button to enable/disable button sound (Default is OFF)
+                      <br />- Only Dispatch can clear the signal 100 by pressing on the banner at the top
+                      <br />
+                      <strong><u>Updated:</u></strong>
+                      <br />- N/A
+                    </p>
+                    <p>For more info on this release view our release log: <a
+                        href="https://github.com/Linesmerrill/police-cad/releases/tag/v2.7.0">Release v2.7.0</a></p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
             <div id="Release-2.6.0" class="grid__cell grid__cell--medium">
               <div class="grid__cell-content">
                 <h2>Release 2.6.0</h2>


### PR DESCRIPTION
# Release 2.7.0 Adds a Signal 100 Button for Dispatch

New:
- Adds a new Signal 100 Button for Dispatch
- Will show up across all police and dispatch pages in your community at the top
- Plays sound when signal 100 button is pressed (mobile functionality is limited due to Safari and Chrome restrictions)
- Use same setting as panic button to enable/disable button sound (Default is OFF)
- Only Dispatch can clear the signal 100 by pressing on the banner at the top
Updated:
- N/A