### PR TITLE
creates a split before inserting into db to better handle duplicates

### DIFF
--- a/app/models/firearm.js
+++ b/app/models/firearm.js
@@ -6,6 +6,7 @@ var firearmSchema = mongoose.Schema({
         serialNumber: String,
         weaponType: String,
         registeredOwner: String,
+        registeredOwnerID: String,
         isStolen: String,
         activeCommunityID: String,
         userID: String,
@@ -19,6 +20,23 @@ firearmSchema.methods.createFirearm = function (req, res) {
     this.firearm.serialNumber = req.body.serialNumber;
     this.firearm.weaponType = req.body.weaponType;
     this.firearm.registeredOwner = req.body.registeredOwner.trim();
+    // hacky af, goal here is to separate the person_id from the person name and dob.
+    // example: 5eeaebb7e23cba396869becb+Rodger Pike | DOB: 2001-01-01
+    // caveat here being that if the name includes a "+" then it will incorrectly split
+    // and probably cause problems. TODO: fix this edge case.
+    if (this.firearm.registeredOwner.includes("+")) {
+        let idPlusRegisteredOwner = this.firearm.registeredOwner.split("+")
+        if (idPlusRegisteredOwner.length == 2) {
+            this.firearm.registeredOwner = idPlusRegisteredOwner[1];
+            this.firearm.registeredOwnerID = idPlusRegisteredOwner[0];
+        } else {
+            console.error(`invalid split on 'this.firearm.registeredOwner': ${this.firearm.registeredOwner}. Does not contain an array of length 2. Split value: ${idPlusRegisteredOwner}`)
+        }
+    } else if (this.firearm.registeredOwner == 'N/A') {
+        // do nothing, this is acceptable
+    } else {
+        console.error(`error on this.firearm.registeredOwner: ${this.firearm.registeredOwner}. Does not contain a '+'.`)
+    }
     this.firearm.isStolen = req.body.isStolen;
     this.firearm.activeCommunityID = req.body.activeCommunityID; // we set this when submitting the from so it should not be null
     this.firearm.userID = req.body.userID; // we set this when submitting the from so it should not be null

--- a/views/civ-dashboard.ejs
+++ b/views/civ-dashboard.ejs
@@ -567,7 +567,7 @@
                 <select id="registeredOwner-new-firearm" name="registeredOwner" class="form-control">
                   <option value="N/A">N/A</option>
                   <% for(var i=0; i<personas.length; i++) {%>
-                    <option value="<%= personas[i].civilian.firstName %> <%= personas[i].civilian.lastName%> | DOB: <%=personas[i].civilian.birthday%>"><%=i+1%>) <%= personas[i].civilian.firstName %> <%= personas[i].civilian.lastName%> | DOB: <%=personas[i].civilian.birthday%></option>
+                    <option value="<%= personas[i]._id %>+<%= personas[i].civilian.firstName %> <%= personas[i].civilian.lastName%> | DOB: <%=personas[i].civilian.birthday%>"><%=i+1%>) <%= personas[i].civilian.firstName %> <%= personas[i].civilian.lastName%> | DOB: <%=personas[i].civilian.birthday%></option>
                    <% } %>
                 </select>
               </div>
@@ -1513,6 +1513,8 @@
     });
   })
 
+
+
   // check for license-notification 
   if (document.cookie.split(';').some((item) => item.includes('license_notice=hidden'))) {
       hideLicenseNotice()
@@ -1917,7 +1919,13 @@ $.delete = function(url, data, callback, type){
     $('#firearmID').val(myVar[index]._id)
     $('#serial-number-details').val(myVar[index].firearm.serialNumber)
     $('#weapon-type-details').val(myVar[index].firearm.weaponType)
-    $('#registeredOwner-details').val(myVar[index].firearm.registeredOwner)
+    //Because from the backend we already split the person_id from the person name and dob, we now 
+    //need to rejoin those values back together for #registeredOwner-details
+    if (myVar[index].firearm.registeredOwner == 'N/A') {
+      $('#registeredOwner-details').val(`${myVar[index].firearm.registeredOwner}`)
+    } else {
+      $('#registeredOwner-details').val(`${myVar[index].firearm.registeredOwnerID}+${myVar[index].firearm.registeredOwner}`)
+    }
     $('#is-stolen-details').val(myVar[index].firearm.isStolen)
   }
 


### PR DESCRIPTION
So the removal of the `persona_id` actually removed the ability to autocomplete the dropdown when selecting the registered owner on firearm creation or update. This is a little fix to still pass the `persona_id` but then do a little data manipulation in our routes to split the ID from the name and dob.

What you should see as an outcome from this:

No id prefix showing on the card:
![image](https://user-images.githubusercontent.com/15384983/117551398-9451b680-affa-11eb-91a9-56fcb545ae7d.png)

Auto populated dropdown with the proper name:
![image](https://user-images.githubusercontent.com/15384983/117551410-a6cbf000-affa-11eb-98e9-25293efa17d7.png)

On update it shows the new name without id prefix:
![image](https://user-images.githubusercontent.com/15384983/117551427-c105ce00-affa-11eb-86fe-12069022fbcd.png)

The new name auto populated in the dropdown:
![image](https://user-images.githubusercontent.com/15384983/117551432-cf53ea00-affa-11eb-8a4d-341b44ecb618.png)
