### PR TITLE
add/missing-content-router

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -637,29 +637,11 @@ module.exports = function (app, passport, server) {
                         'user.activeCommunity': req.user.user.activeCommunity
                       }, function (err, dbCommUsers) {
                         if (err) return console.error(err);
-                        if (req.user.user.activeCommunity == '' || req.user.user.activeCommunity == null) {
-                          return res.render('dispatch-dashboard', {
-                            user: req.user,
-                            vehicles: null,
-                            civilians: dbCivilians,
-                            firearms: null,
-                            tickets: dbTickets,
-                            arrestReports: dbArrestReports,
-                            warrants: dbWarrants,
-                            dbEmsEngines: null,
-                            communities: dbCommunities,
-                            commUsers: dbCommUsers,
-                            bolos: dbBolos,
-                            calls: dbCalls,
-                            context: null,
-                            referer: encodeURIComponent('/dispatch-dashboard'),
-                            redirect: encodeURIComponent(redirect)
-                          });
-                        } else {
-                          User.find({
-                            'user.activeCommunity': req.user.user.activeCommunity
-                          }, function (err, dbCommUsers) {
-                            if (err) return console.error(err);
+                        EmsVehicle.find({
+                          'emsVehicle.activeCommunityID': req.user.user.activeCommunity
+                        }, function (err, dbEmsEngines) {
+                          if (err) return console.error(err);
+                          if (req.user.user.activeCommunity == '' || req.user.user.activeCommunity == null) {
                             return res.render('dispatch-dashboard', {
                               user: req.user,
                               vehicles: null,
@@ -668,6 +650,7 @@ module.exports = function (app, passport, server) {
                               tickets: dbTickets,
                               arrestReports: dbArrestReports,
                               warrants: dbWarrants,
+                              dbEmsEngines: null,
                               communities: dbCommunities,
                               commUsers: dbCommUsers,
                               bolos: dbBolos,
@@ -676,8 +659,31 @@ module.exports = function (app, passport, server) {
                               referer: encodeURIComponent('/dispatch-dashboard'),
                               redirect: encodeURIComponent(redirect)
                             });
-                          });
-                        }
+                          } else {
+                            User.find({
+                              'user.activeCommunity': req.user.user.activeCommunity
+                            }, function (err, dbCommUsers) {
+                              if (err) return console.error(err);
+                              return res.render('dispatch-dashboard', {
+                                user: req.user,
+                                vehicles: null,
+                                civilians: dbCivilians,
+                                firearms: null,
+                                tickets: dbTickets,
+                                arrestReports: dbArrestReports,
+                                warrants: dbWarrants,
+                                dbEmsEngines: dbEmsEngines,
+                                communities: dbCommunities,
+                                commUsers: dbCommUsers,
+                                bolos: dbBolos,
+                                calls: dbCalls,
+                                context: null,
+                                referer: encodeURIComponent('/dispatch-dashboard'),
+                                redirect: encodeURIComponent(redirect)
+                              });
+                            });
+                          }
+                        });
                       });
                     });
                   })
@@ -765,6 +771,7 @@ module.exports = function (app, passport, server) {
                                 tickets: dbTickets,
                                 arrestReports: dbArrestReports,
                                 warrants: dbWarrants,
+                                dbEmsEngines: dbEmsEngines,
                                 communities: dbCommunities,
                                 commUsers: dbCommUsers,
                                 bolos: dbBolos,


### PR DESCRIPTION
Fixes `name-search` post request redirect to have `dbEmsEngines` value to stop `Internal Server Error` crash.