### PR TITLE
feat: migrate EMS/Fire dashboards to department-dashboard

### DIFF
--- a/public/js/dd-bolos.js
+++ b/public/js/dd-bolos.js
@@ -1,0 +1,947 @@
+/**
+ * Department Dashboard — BOLOs & Warrants Components
+ *
+ * Exports:
+ *   window.ddBoloCreateRender / window.ddBoloCreateInit  — BOLO management (create/edit/delete)
+ *   window.ddBoloViewRender   / window.ddBoloViewInit    — Read-only BOLOs + warrants view
+ */
+(function () {
+  'use strict';
+
+  /* ───────────────────────────────────────────
+     Helpers & Config
+     ─────────────────────────────────────────── */
+
+  var cfg = function () { return window.ddConfig || {}; };
+  var esc = function (s) { return window.esc ? window.esc(s) : String(s || '').replace(/[&<>"']/g, function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];}); };
+  var toast = function (m, t) { if (window.ddToast) window.ddToast(m, t); };
+
+  function cap(s) { return s ? s.charAt(0).toUpperCase() + s.slice(1) : ''; }
+  function fmtDate(d) {
+    if (!d) return 'N/A';
+    var dt = new Date(d);
+    if (isNaN(dt) || dt.getFullYear() <= 1970) return 'N/A';
+    var h = dt.getHours(), m = dt.getMinutes();
+    var ampm = h >= 12 ? 'PM' : 'AM';
+    h = h % 12 || 12;
+    return (dt.getMonth()+1) + '/' + dt.getDate() + '/' + dt.getFullYear() + ' ' + h + ':' + (m < 10 ? '0' : '') + m + ampm;
+  }
+
+  /* ═══════════════════════════════════════════
+     BOLO MANAGEMENT (createBolos component)
+     ═══════════════════════════════════════════ */
+
+  var boloPage = 0;
+  var boloLimit = 10;
+  var boloTotal = 0;
+  var boloData = [];
+  var boloNewModalReady = false;
+  var boloDetailModalReady = false;
+
+  /* ───────────────────────────────────────────
+     Styles
+     ─────────────────────────────────────────── */
+
+  function injectBoloStyles() {
+    if (document.getElementById('dd-bolo-styles')) return;
+
+    var css = '' +
+      '.dd-bolo-toolbar{display:flex;align-items:center;gap:0.625rem;flex-wrap:wrap;margin-bottom:0.875rem;}' +
+      '.dd-bolo-add-btn{padding:0.5rem 0.875rem;border-radius:var(--dd-radius-sm);border:1px solid rgba(245,158,11,0.25);background:rgba(245,158,11,0.1);color:#fcd34d;font-family:inherit;font-size:0.75rem;font-weight:500;cursor:pointer;transition:all 0.2s;white-space:nowrap;display:inline-flex;align-items:center;gap:0.375rem;}' +
+      '.dd-bolo-add-btn:hover{background:rgba(245,158,11,0.18);border-color:rgba(245,158,11,0.4);color:#fde68a;}' +
+
+      /* Tabs */
+      '.dd-bolo-tabs{display:flex;gap:0.25rem;margin-bottom:0.75rem;background:var(--dd-glass);border:1.5px solid var(--dd-glass-border);border-radius:8px;padding:0.2rem;}' +
+      '.dd-bolo-tab{background:transparent;color:var(--dd-text-muted);border:none;border-radius:6px;padding:0.4rem 0.75rem;font-size:0.75rem;font-weight:500;cursor:pointer;transition:all 0.2s;flex:1;text-align:center;}' +
+      '.dd-bolo-tab.active{background:var(--dd-amber);color:#fff;}' +
+
+      /* List */
+      '.dd-bolo-list{display:flex;flex-direction:column;gap:0.5rem;}' +
+      '.dd-bolo-item{background:var(--dd-glass);border:1px solid var(--dd-glass-border);border-radius:var(--dd-radius);padding:0.875rem 1rem;cursor:pointer;transition:all 0.2s;display:flex;align-items:flex-start;gap:0.75rem;}' +
+      '.dd-bolo-item:hover{background:rgba(255,255,255,0.06);border-color:rgba(255,255,255,0.12);transform:translateY(-1px);}' +
+      '.dd-bolo-item-icon{width:36px;height:36px;border-radius:var(--dd-radius-sm);flex-shrink:0;display:flex;align-items:center;justify-content:center;font-size:0.875rem;color:var(--dd-amber);background:rgba(245,158,11,0.1);}' +
+      '.dd-bolo-item-info{flex:1;min-width:0;}' +
+      '.dd-bolo-item-title{font-size:0.875rem;font-weight:600;color:var(--dd-text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}' +
+      '.dd-bolo-item-meta{font-size:0.75rem;color:var(--dd-text-muted);margin-top:0.15rem;}' +
+      '.dd-bolo-item-desc{font-size:0.75rem;color:var(--dd-text-dim);margin-top:0.25rem;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;}' +
+      '.dd-bolo-badge-active{display:inline-block;font-size:0.625rem;font-weight:600;padding:0.15rem 0.5rem;border-radius:999px;background:rgba(34,197,94,0.15);color:var(--dd-green);}' +
+      '.dd-bolo-badge-inactive{display:inline-block;font-size:0.625rem;font-weight:600;padding:0.15rem 0.5rem;border-radius:999px;background:rgba(100,116,139,0.15);color:var(--dd-text-muted);}' +
+
+      /* Pagination */
+      '.dd-bolo-pagination{display:flex;align-items:center;justify-content:center;gap:0.75rem;margin-top:1rem;}' +
+      '.dd-bolo-page-info{font-size:0.75rem;color:var(--dd-text-muted);}' +
+      '.dd-bolo-page-btn{background:var(--dd-glass);border:1px solid var(--dd-glass-border);border-radius:var(--dd-radius);color:var(--dd-text);padding:0.35rem 0.75rem;font-size:0.75rem;cursor:pointer;transition:all 0.2s;font-family:inherit;}' +
+      '.dd-bolo-page-btn:hover:not(:disabled){background:rgba(255,255,255,0.06);}' +
+      '.dd-bolo-page-btn:disabled{opacity:0.35;cursor:default;}' +
+
+      /* Scope radio */
+      '.dd-bolo-scope-row{display:flex;gap:1rem;grid-column:1/-1;margin-top:0.25rem;}' +
+      '.dd-bolo-scope-opt{display:flex;align-items:center;gap:0.35rem;font-size:0.8125rem;color:var(--dd-text);cursor:pointer;}' +
+      '.dd-bolo-scope-opt input{accent-color:var(--dd-amber);cursor:pointer;}' +
+
+      /* Responsive */
+      '@media(max-width:600px){' +
+        '.dd-bolo-toolbar{flex-direction:column;align-items:stretch;}' +
+      '}' +
+    '';
+
+    var style = document.createElement('style');
+    style.id = 'dd-bolo-styles';
+    style.textContent = css;
+    document.head.appendChild(style);
+  }
+
+  /* ───────────────────────────────────────────
+     createBolos: Render
+     ─────────────────────────────────────────── */
+
+  function ddBoloCreateRender() {
+    return '' +
+      '<div class="dd-card-header">' +
+        '<div class="dd-card-header-left">' +
+          '<div class="dd-card-icon" style="background:rgba(245,158,11,0.15);color:var(--dd-amber);"><i class="fa fa-bullhorn"></i></div>' +
+          '<div><h3 class="dd-card-title">BOLOs</h3><p class="dd-card-subtitle">Manage Be On Lookout alerts</p></div>' +
+        '</div>' +
+      '</div>' +
+      '<div class="dd-card-body">' +
+        '<div class="dd-bolo-toolbar">' +
+          '<button class="dd-bolo-add-btn" id="dd-bolo-add-btn"><i class="fa fa-plus"></i> Create BOLO</button>' +
+        '</div>' +
+        '<div class="dd-bolo-loading dd-spinner"></div>' +
+        '<div class="dd-bolo-empty dd-empty" style="display:none;">' +
+          '<div class="dd-empty-icon-wrap" style="background:rgba(245,158,11,0.08);border-color:rgba(245,158,11,0.15);">' +
+            '<i class="fa fa-bullhorn" style="color:var(--dd-amber);"></i>' +
+          '</div>' +
+          '<p class="dd-empty-title">No BOLOs found</p>' +
+          '<p class="dd-empty-sub">Create your first BOLO alert</p>' +
+        '</div>' +
+        '<div id="dd-bolo-list" class="dd-bolo-list" style="display:none;"></div>' +
+        '<div class="dd-bolo-pagination" id="dd-bolo-pagination" style="display:none;">' +
+          '<button class="dd-bolo-page-btn" id="dd-bolo-prev"><i class="fa fa-chevron-left"></i> Prev</button>' +
+          '<span class="dd-bolo-page-info" id="dd-bolo-page-info">Page 1</span>' +
+          '<button class="dd-bolo-page-btn" id="dd-bolo-next">Next <i class="fa fa-chevron-right"></i></button>' +
+        '</div>' +
+      '</div>';
+  }
+
+  /* ───────────────────────────────────────────
+     createBolos: Init
+     ─────────────────────────────────────────── */
+
+  function ddBoloCreateInit() {
+    injectBoloStyles();
+    boloPage = 0;
+    wireBoloEvents();
+    loadBolos();
+  }
+
+  function wireBoloEvents() {
+    $(document).off('click.ddBolo', '#dd-bolo-add-btn')
+      .on('click.ddBolo', '#dd-bolo-add-btn', openBoloNewModal);
+
+    $(document).off('click.ddBolo', '#dd-bolo-prev')
+      .on('click.ddBolo', '#dd-bolo-prev', function () {
+        if (boloPage > 0) { boloPage--; loadBolos(); }
+      });
+
+    $(document).off('click.ddBolo', '#dd-bolo-next')
+      .on('click.ddBolo', '#dd-bolo-next', function () {
+        if ((boloPage + 1) * boloLimit < boloTotal) { boloPage++; loadBolos(); }
+      });
+
+    $(document).off('click.ddBolo', '.dd-bolo-item')
+      .on('click.ddBolo', '.dd-bolo-item', function () {
+        var id = $(this).attr('data-bolo-id');
+        if (id) openBoloDetailModal(id);
+      });
+  }
+
+  /* ───────────────────────────────────────────
+     createBolos: Load
+     ─────────────────────────────────────────── */
+
+  function loadBolos() {
+    var c = cfg();
+    var $list = $('#dd-bolo-list');
+    var $loading = $('.dd-bolo-loading');
+    var $empty = $('.dd-bolo-empty');
+    var $pagination = $('#dd-bolo-pagination');
+
+    $list.hide(); $empty.hide(); $pagination.hide();
+    $loading.show();
+
+    var deptData = c.departmentData || {};
+    var deptId = deptData._id || c.departmentId || '';
+
+    $.ajax({
+      url: c.API_URL + '/api/v1/bolos' +
+        '?communityId=' + encodeURIComponent(c.communityId) +
+        '&departmentId=' + encodeURIComponent(deptId) +
+        '&limit=' + boloLimit +
+        '&page=' + boloPage,
+      method: 'GET',
+      success: function (data) {
+        $loading.hide();
+        boloData = data.data || [];
+        boloTotal = data.totalCount || boloData.length;
+        renderBoloList();
+      },
+      error: function () {
+        $loading.hide();
+        boloData = [];
+        renderBoloList();
+        toast('Failed to load BOLOs', 'error');
+      }
+    });
+  }
+
+  function renderBoloList() {
+    var $list = $('#dd-bolo-list');
+    var $empty = $('.dd-bolo-empty');
+    $list.empty();
+
+    if (!boloData.length) {
+      $list.hide();
+      $empty.show();
+      updateBoloPagination();
+      return;
+    }
+
+    $empty.hide();
+    $list.show();
+
+    boloData.forEach(function (item) {
+      var b = item.bolo || item || {};
+      var statusCls = b.status ? 'dd-bolo-badge-active' : 'dd-bolo-badge-inactive';
+      var statusLabel = b.status ? 'Active' : 'Inactive';
+
+      $list.append(
+        '<div class="dd-bolo-item" data-bolo-id="' + esc(item._id) + '">' +
+          '<div class="dd-bolo-item-icon"><i class="fa fa-bullhorn"></i></div>' +
+          '<div class="dd-bolo-item-info">' +
+            '<div style="display:flex;align-items:center;gap:0.5rem;">' +
+              '<div class="dd-bolo-item-title">' + esc(b.title || 'Untitled') + '</div>' +
+              '<span class="' + statusCls + '">' + statusLabel + '</span>' +
+            '</div>' +
+            '<div class="dd-bolo-item-meta">' +
+              '<i class="fa fa-map-marker-alt" style="opacity:0.5;"></i> ' + esc(b.location || 'Unknown') +
+              ' &middot; ' + fmtDate(b.createdAt) +
+              (b.scope ? ' &middot; ' + esc(b.scope) : '') +
+            '</div>' +
+            (b.description ? '<div class="dd-bolo-item-desc">' + esc(b.description) + '</div>' : '') +
+          '</div>' +
+        '</div>'
+      );
+    });
+
+    updateBoloPagination();
+  }
+
+  function updateBoloPagination() {
+    var $pagination = $('#dd-bolo-pagination');
+    if (boloTotal <= boloLimit && boloPage === 0) { $pagination.hide(); return; }
+
+    $pagination.show();
+    var totalPages = Math.max(1, Math.ceil(boloTotal / boloLimit));
+    $('#dd-bolo-page-info').text('Page ' + (boloPage + 1) + ' of ' + totalPages);
+    $('#dd-bolo-prev').prop('disabled', boloPage <= 0);
+    $('#dd-bolo-next').prop('disabled', (boloPage + 1) * boloLimit >= boloTotal);
+  }
+
+  /* ───────────────────────────────────────────
+     createBolos: New Modal
+     ─────────────────────────────────────────── */
+
+  function ensureBoloNewModal() {
+    if (boloNewModalReady) return;
+    boloNewModalReady = true;
+
+    var html = '' +
+      '<div class="dd-civ-new-overlay" id="dd-bolo-new-overlay">' +
+        '<div class="dd-civ-new-panel" style="max-width:560px;">' +
+          '<div class="dd-civ-new-header">' +
+            '<span class="dd-civ-new-title" id="dd-bolo-new-title">New BOLO</span>' +
+            '<button class="dd-civ-close" id="dd-bolo-new-close"><i class="fa fa-times"></i></button>' +
+          '</div>' +
+          '<div class="dd-civ-new-body">' +
+            '<div class="dd-civ-form-grid">' +
+              '<div class="dd-civ-field dd-civ-form-full"><label>Title *</label><input type="text" id="dd-bolo-new-title-input" maxlength="50" placeholder="e.g. Missing Person"></div>' +
+              '<div class="dd-civ-field"><label>Location *</label><input type="text" id="dd-bolo-new-location" maxlength="50" placeholder="e.g. Downtown"></div>' +
+              '<div class="dd-civ-field"><label>Scope</label>' +
+                '<div class="dd-bolo-scope-row">' +
+                  '<label class="dd-bolo-scope-opt"><input type="radio" name="dd-bolo-scope" value="Community" checked> Community</label>' +
+                  '<label class="dd-bolo-scope-opt"><input type="radio" name="dd-bolo-scope" value="Department"> Department</label>' +
+                '</div>' +
+              '</div>' +
+              '<div class="dd-civ-field dd-civ-form-full"><label>Description *</label><textarea id="dd-bolo-new-desc" maxlength="500" rows="4" placeholder="Detailed description..." style="resize:vertical;"></textarea></div>' +
+            '</div>' +
+          '</div>' +
+          '<div class="dd-civ-new-footer">' +
+            '<button class="dd-civ-btn dd-civ-btn-secondary" id="dd-bolo-new-cancel">Cancel</button>' +
+            '<button class="dd-civ-btn dd-civ-btn-primary" id="dd-bolo-new-save"><i class="fa fa-plus"></i> Create</button>' +
+          '</div>' +
+        '</div>' +
+      '</div>';
+
+    $('body').append(html);
+
+    $(document).off('click.ddBoloNew', '#dd-bolo-new-close, #dd-bolo-new-cancel')
+      .on('click.ddBoloNew', '#dd-bolo-new-close, #dd-bolo-new-cancel', closeBoloNewModal);
+    $(document).off('click.ddBoloNew', '#dd-bolo-new-overlay')
+      .on('click.ddBoloNew', '#dd-bolo-new-overlay', function (e) { if (e.target === this) closeBoloNewModal(); });
+    $(document).off('click.ddBoloNew', '#dd-bolo-new-save')
+      .on('click.ddBoloNew', '#dd-bolo-new-save', createBolo);
+  }
+
+  function openBoloNewModal() {
+    ensureBoloNewModal();
+    $('#dd-bolo-new-title-input').val('');
+    $('#dd-bolo-new-location').val('');
+    $('#dd-bolo-new-desc').val('');
+    $('input[name="dd-bolo-scope"][value="Community"]').prop('checked', true);
+    $('#dd-bolo-new-title').text('New BOLO');
+    var $btn = $('#dd-bolo-new-save');
+    $btn.prop('disabled', false).html('<i class="fa fa-plus"></i> Create');
+    $btn.off('click.ddBoloNew').on('click.ddBoloNew', createBolo);
+    $('#dd-bolo-new-overlay').addClass('dd-civ-visible');
+  }
+
+  function closeBoloNewModal() {
+    $('#dd-bolo-new-overlay').removeClass('dd-civ-visible');
+  }
+
+  function createBolo() {
+    var title = $('#dd-bolo-new-title-input').val().trim();
+    var location = $('#dd-bolo-new-location').val().trim();
+    var description = $('#dd-bolo-new-desc').val().trim();
+    var scope = $('input[name="dd-bolo-scope"]:checked').val() || 'Community';
+    var c = cfg();
+
+    if (!title || !location || !description) {
+      toast('Please fill in all required fields', 'error');
+      return;
+    }
+
+    var deptData = c.departmentData || {};
+    var $btn = $('#dd-bolo-new-save');
+    $btn.prop('disabled', true).html('<i class="fa fa-spinner fa-spin"></i> Creating...');
+
+    $.ajax({
+      url: c.API_URL + '/api/v1/bolo',
+      method: 'POST',
+      contentType: 'application/json',
+      data: JSON.stringify({
+        bolo: {
+          title: title,
+          location: location,
+          description: description,
+          scope: scope,
+          communityID: c.communityId,
+          departmentID: deptData._id || c.departmentId || '',
+          reportedByID: c.userId,
+          status: true
+        }
+      }),
+      success: function () {
+        toast('BOLO created successfully', 'success');
+        closeBoloNewModal();
+        boloPage = 0;
+        loadBolos();
+      },
+      error: function (xhr) {
+        var msg = 'Failed to create BOLO';
+        try { msg = JSON.parse(xhr.responseText).error || msg; } catch (e) {}
+        toast(msg, 'error');
+      },
+      complete: function () {
+        $btn.prop('disabled', false).html('<i class="fa fa-plus"></i> Create');
+      }
+    });
+  }
+
+  /* ───────────────────────────────────────────
+     createBolos: Detail Modal
+     ─────────────────────────────────────────── */
+
+  function ensureBoloDetailModal() {
+    if (boloDetailModalReady) return;
+    boloDetailModalReady = true;
+
+    var html = '' +
+      '<div class="dd-civ-new-overlay" id="dd-bolo-detail-overlay">' +
+        '<div class="dd-civ-new-panel" style="max-width:560px;">' +
+          '<div class="dd-civ-new-header">' +
+            '<span class="dd-civ-new-title" id="dd-bolo-detail-title">BOLO Details</span>' +
+            '<button class="dd-civ-close" id="dd-bolo-detail-close"><i class="fa fa-times"></i></button>' +
+          '</div>' +
+          '<div class="dd-civ-new-body" id="dd-bolo-detail-body"><div class="dd-spinner"></div></div>' +
+          '<div class="dd-civ-new-footer" id="dd-bolo-detail-footer"></div>' +
+        '</div>' +
+      '</div>';
+
+    $('body').append(html);
+
+    $(document).off('click.ddBoloDetail', '#dd-bolo-detail-close')
+      .on('click.ddBoloDetail', '#dd-bolo-detail-close', closeBoloDetailModal);
+    $(document).off('click.ddBoloDetail', '#dd-bolo-detail-overlay')
+      .on('click.ddBoloDetail', '#dd-bolo-detail-overlay', function (e) { if (e.target === this) closeBoloDetailModal(); });
+  }
+
+  function openBoloDetailModal(id) {
+    ensureBoloDetailModal();
+    var $overlay = $('#dd-bolo-detail-overlay');
+    var $body = $('#dd-bolo-detail-body');
+    var $footer = $('#dd-bolo-detail-footer');
+
+    $body.html('<div class="dd-spinner"></div>');
+    $footer.empty();
+    $overlay.addClass('dd-civ-visible');
+
+    var c = cfg();
+    $.ajax({
+      url: c.API_URL + '/api/v1/bolo/' + encodeURIComponent(id),
+      method: 'GET',
+      success: function (data) {
+        var b = data.bolo || data || {};
+
+        var fields = [
+          { label: 'Title', val: b.title },
+          { label: 'Location', val: b.location },
+          { label: 'Scope', val: b.scope },
+          { label: 'Status', val: b.status ? 'Active' : 'Inactive' },
+          { label: 'Created', val: fmtDate(b.createdAt) },
+          { label: 'Updated', val: fmtDate(b.updatedAt) }
+        ];
+
+        var html = '<div class="dd-civ-form-grid">';
+        fields.forEach(function (f) {
+          html += '<div class="dd-civ-field"><label>' + esc(f.label) + '</label>' +
+            '<div style="padding:0.5rem 0;color:var(--dd-text);font-size:0.875rem;">' + esc(f.val || 'N/A') + '</div></div>';
+        });
+        if (b.description) {
+          html += '<div class="dd-civ-field dd-civ-form-full"><label>Description</label>' +
+            '<div style="padding:0.5rem 0;color:var(--dd-text);font-size:0.875rem;line-height:1.6;">' + esc(b.description) + '</div></div>';
+        }
+        html += '</div>';
+
+        $('#dd-bolo-detail-title').text(b.title || 'BOLO Details');
+        $body.html(html);
+        $footer.html(
+          '<button class="dd-civ-btn dd-civ-btn-primary dd-civ-btn-small" id="dd-bolo-edit-btn" data-id="' + esc(id) + '"><i class="fa fa-edit"></i> Edit</button>' +
+          '<button class="dd-civ-btn dd-civ-btn-danger dd-civ-btn-small" id="dd-bolo-del-btn" data-id="' + esc(id) + '"><i class="fa fa-trash"></i> Delete</button>'
+        );
+      },
+      error: function () {
+        $body.html('<p style="color:var(--dd-red);">Failed to load BOLO details</p>');
+        toast('Failed to load BOLO details', 'error');
+      }
+    });
+  }
+
+  function closeBoloDetailModal() {
+    $('#dd-bolo-detail-overlay').removeClass('dd-civ-visible');
+  }
+
+  // Edit
+  $(document).on('click.ddBolo', '#dd-bolo-edit-btn', function () {
+    var id = $(this).attr('data-id');
+    closeBoloDetailModal();
+    openBoloEditModal(id);
+  });
+
+  // Delete
+  $(document).on('click.ddBolo', '#dd-bolo-del-btn', function () {
+    var id = $(this).attr('data-id');
+    if (window.ddModal) {
+      window.ddModal({
+        title: 'Delete BOLO',
+        message: 'Are you sure you want to delete this BOLO? This action cannot be undone.',
+        confirmLabel: 'Delete',
+        confirmClass: 'dd-civ-btn-danger',
+        onConfirm: function () { deleteBolo(id); }
+      });
+    } else {
+      if (confirm('Delete this BOLO?')) deleteBolo(id);
+    }
+  });
+
+  function openBoloEditModal(id) {
+    ensureBoloNewModal();
+    var c = cfg();
+    var $overlay = $('#dd-bolo-new-overlay');
+
+    $overlay.addClass('dd-civ-visible');
+    $('#dd-bolo-new-save').prop('disabled', true).html('<i class="fa fa-spinner fa-spin"></i>');
+
+    $.ajax({
+      url: c.API_URL + '/api/v1/bolo/' + encodeURIComponent(id),
+      method: 'GET',
+      success: function (data) {
+        var b = data.bolo || data || {};
+        $('#dd-bolo-new-title-input').val(b.title || '');
+        $('#dd-bolo-new-location').val(b.location || '');
+        $('#dd-bolo-new-desc').val(b.description || '');
+        $('input[name="dd-bolo-scope"][value="' + (b.scope || 'Community') + '"]').prop('checked', true);
+        $('#dd-bolo-new-title').text('Edit BOLO');
+
+        var $btn = $('#dd-bolo-new-save');
+        $btn.prop('disabled', false).html('<i class="fa fa-save"></i> Update');
+        $btn.off('click.ddBoloNew').on('click.ddBoloNew', function () { updateBolo(id); });
+      },
+      error: function () {
+        toast('Failed to load BOLO for editing', 'error');
+        closeBoloNewModal();
+      }
+    });
+  }
+
+  function updateBolo(id) {
+    var title = $('#dd-bolo-new-title-input').val().trim();
+    var location = $('#dd-bolo-new-location').val().trim();
+    var description = $('#dd-bolo-new-desc').val().trim();
+    var c = cfg();
+
+    if (!title || !location || !description) {
+      toast('Please fill in all required fields', 'error');
+      return;
+    }
+
+    var $btn = $('#dd-bolo-new-save');
+    $btn.prop('disabled', true).html('<i class="fa fa-spinner fa-spin"></i> Updating...');
+
+    $.ajax({
+      url: c.API_URL + '/api/v1/bolo/' + encodeURIComponent(id),
+      method: 'PUT',
+      contentType: 'application/json',
+      data: JSON.stringify({
+        bolo: {
+          title: title,
+          location: location,
+          description: description
+        }
+      }),
+      success: function () {
+        toast('BOLO updated successfully', 'success');
+        closeBoloNewModal();
+        $('#dd-bolo-new-save').off('click.ddBoloNew').on('click.ddBoloNew', createBolo);
+        loadBolos();
+      },
+      error: function (xhr) {
+        var msg = 'Failed to update BOLO';
+        try { msg = JSON.parse(xhr.responseText).error || msg; } catch (e) {}
+        toast(msg, 'error');
+      },
+      complete: function () {
+        $btn.prop('disabled', false).html('<i class="fa fa-save"></i> Update');
+      }
+    });
+  }
+
+  function deleteBolo(id) {
+    var c = cfg();
+    $.ajax({
+      url: c.API_URL + '/api/v1/bolo/' + encodeURIComponent(id),
+      method: 'DELETE',
+      success: function () {
+        toast('BOLO deleted successfully', 'success');
+        closeBoloDetailModal();
+        loadBolos();
+      },
+      error: function () {
+        toast('Failed to delete BOLO', 'error');
+      }
+    });
+  }
+
+
+  /* ═══════════════════════════════════════════
+     VIEW BOLOs & WARRANTS (viewBolosAndWarrants)
+     ═══════════════════════════════════════════ */
+
+  var viewTab = 'bolos'; // 'bolos' or 'warrants'
+  var viewBoloPage = 0;
+  var viewBoloLimit = 10;
+  var viewBoloTotal = 0;
+  var viewBoloData = [];
+  var wmPage = 0;
+  var wmLimit = 8;
+  var wmTotalPages = 1;
+  var wmDetailReady = false;
+
+  /* ───────────────────────────────────────────
+     viewBolosAndWarrants: Render
+     ─────────────────────────────────────────── */
+
+  function ddBoloViewRender() {
+    return '' +
+      '<div class="dd-card-header">' +
+        '<div class="dd-card-header-left">' +
+          '<div class="dd-card-icon" style="background:rgba(245,158,11,0.15);color:var(--dd-amber);"><i class="fa fa-eye"></i></div>' +
+          '<div><h3 class="dd-card-title">BOLOs & Warrants</h3><p class="dd-card-subtitle">View active alerts and warrants</p></div>' +
+        '</div>' +
+      '</div>' +
+      '<div class="dd-card-body">' +
+        '<div class="dd-bolo-tabs" id="dd-bv-tabs">' +
+          '<button class="dd-bolo-tab active" data-bv-tab="bolos">BOLOs</button>' +
+          '<button class="dd-bolo-tab" data-bv-tab="warrants">Warrants</button>' +
+        '</div>' +
+        '<div id="dd-bv-content"></div>' +
+      '</div>';
+  }
+
+  /* ───────────────────────────────────────────
+     viewBolosAndWarrants: Init
+     ─────────────────────────────────────────── */
+
+  function ddBoloViewInit() {
+    injectBoloStyles();
+    injectWarrantStyles();
+    viewTab = 'bolos';
+    viewBoloPage = 0;
+    wmPage = 0;
+
+    $(document).off('click.ddBV', '.dd-bolo-tab[data-bv-tab]')
+      .on('click.ddBV', '.dd-bolo-tab[data-bv-tab]', function () {
+        var tab = $(this).attr('data-bv-tab');
+        if (tab === viewTab) return;
+        viewTab = tab;
+        $('#dd-bv-tabs .dd-bolo-tab').removeClass('active');
+        $(this).addClass('active');
+        if (tab === 'bolos') loadViewBolos();
+        else loadWarrants();
+      });
+
+    loadViewBolos();
+  }
+
+  /* ── BOLOs tab ── */
+
+  function loadViewBolos() {
+    var c = cfg();
+    var $content = $('#dd-bv-content');
+    $content.html('<div class="dd-spinner"></div>');
+
+    var deptData = c.departmentData || {};
+    var deptId = deptData._id || c.departmentId || '';
+
+    $.ajax({
+      url: c.API_URL + '/api/v1/bolos' +
+        '?communityId=' + encodeURIComponent(c.communityId) +
+        '&departmentId=' + encodeURIComponent(deptId) +
+        '&limit=' + viewBoloLimit +
+        '&page=' + viewBoloPage,
+      method: 'GET',
+      success: function (data) {
+        viewBoloData = data.data || [];
+        viewBoloTotal = data.totalCount || viewBoloData.length;
+        renderViewBolos();
+      },
+      error: function () {
+        $content.html('<div class="dd-empty"><i class="fa fa-bullhorn"></i><p>Failed to load BOLOs</p></div>');
+      }
+    });
+  }
+
+  function renderViewBolos() {
+    var $content = $('#dd-bv-content');
+
+    if (!viewBoloData.length) {
+      $content.html('<div class="dd-empty" style="padding:2rem 1rem;"><div class="dd-empty-icon-wrap" style="background:rgba(245,158,11,0.08);border-color:rgba(245,158,11,0.15);"><i class="fa fa-bullhorn" style="color:var(--dd-amber);"></i></div><p class="dd-empty-title">No BOLOs found</p></div>');
+      return;
+    }
+
+    var html = '<div class="dd-bolo-list">';
+    viewBoloData.forEach(function (item) {
+      var b = item.bolo || item || {};
+      var statusCls = b.status ? 'dd-bolo-badge-active' : 'dd-bolo-badge-inactive';
+      var statusLabel = b.status ? 'Active' : 'Inactive';
+
+      html += '<div class="dd-bolo-item" style="cursor:default;">' +
+        '<div class="dd-bolo-item-icon"><i class="fa fa-bullhorn"></i></div>' +
+        '<div class="dd-bolo-item-info">' +
+          '<div style="display:flex;align-items:center;gap:0.5rem;">' +
+            '<div class="dd-bolo-item-title">' + esc(b.title || 'Untitled') + '</div>' +
+            '<span class="' + statusCls + '">' + statusLabel + '</span>' +
+          '</div>' +
+          '<div class="dd-bolo-item-meta">' +
+            '<i class="fa fa-map-marker-alt" style="opacity:0.5;"></i> ' + esc(b.location || 'Unknown') +
+            ' &middot; ' + fmtDate(b.createdAt) +
+          '</div>' +
+          (b.description ? '<div class="dd-bolo-item-desc">' + esc(b.description) + '</div>' : '') +
+        '</div>' +
+      '</div>';
+    });
+    html += '</div>';
+
+    // Pagination
+    if (viewBoloTotal > viewBoloLimit || viewBoloPage > 0) {
+      var totalPages = Math.max(1, Math.ceil(viewBoloTotal / viewBoloLimit));
+      html += '<div class="dd-bolo-pagination">' +
+        '<button class="dd-bolo-page-btn" id="dd-bv-bolo-prev"' + (viewBoloPage <= 0 ? ' disabled' : '') + '><i class="fa fa-chevron-left"></i> Prev</button>' +
+        '<span class="dd-bolo-page-info">Page ' + (viewBoloPage + 1) + ' of ' + totalPages + '</span>' +
+        '<button class="dd-bolo-page-btn" id="dd-bv-bolo-next"' + ((viewBoloPage + 1) * viewBoloLimit >= viewBoloTotal ? ' disabled' : '') + '>Next <i class="fa fa-chevron-right"></i></button>' +
+      '</div>';
+    }
+
+    $content.html(html);
+
+    $(document).off('click.ddBVPag', '#dd-bv-bolo-prev').on('click.ddBVPag', '#dd-bv-bolo-prev', function () {
+      if (viewBoloPage > 0) { viewBoloPage--; loadViewBolos(); }
+    });
+    $(document).off('click.ddBVPag', '#dd-bv-bolo-next').on('click.ddBVPag', '#dd-bv-bolo-next', function () {
+      if ((viewBoloPage + 1) * viewBoloLimit < viewBoloTotal) { viewBoloPage++; loadViewBolos(); }
+    });
+  }
+
+  /* ── Warrants tab (read-only) ── */
+
+  function injectWarrantStyles() {
+    if (document.getElementById('dd-bv-warrant-styles')) return;
+
+    var css = '' +
+      '.dd-wm-notice{background:rgba(59,130,246,0.08);border:1px solid rgba(59,130,246,0.2);border-radius:var(--dd-radius-sm);padding:0.625rem 0.875rem;margin-bottom:0.75rem;font-size:0.75rem;color:#93c5fd;display:flex;align-items:center;gap:0.5rem;}' +
+      '.dd-wm-search-bar{display:flex;gap:0.5rem;flex-wrap:wrap;margin-bottom:0.75rem;}' +
+      '.dd-wm-input{background:var(--dd-glass);border:1px solid var(--dd-glass-border);border-radius:var(--dd-radius-sm);padding:0.5rem 0.65rem;color:var(--dd-text);font-family:inherit;font-size:0.8125rem;outline:none;transition:border-color 0.2s;flex:1;min-width:120px;}' +
+      '.dd-wm-input:focus{border-color:rgba(255,255,255,0.15);}' +
+      '.dd-wm-input option{background:#1a1a24;color:var(--dd-text);}' +
+      '.dd-wm-search-btn{padding:0.5rem 1rem;border-radius:var(--dd-radius-sm);border:1px solid rgba(59,130,246,0.25);background:rgba(59,130,246,0.1);color:#93c5fd;font-family:inherit;font-size:0.8125rem;font-weight:500;cursor:pointer;transition:all 0.2s;white-space:nowrap;display:inline-flex;align-items:center;gap:0.375rem;}' +
+      '.dd-wm-search-btn:hover{background:rgba(59,130,246,0.18);}' +
+
+      '.dd-wm-cards{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:0.5rem;}' +
+      '.dd-wm-card{background:var(--dd-glass);border:1px solid var(--dd-glass-border);border-radius:var(--dd-radius);padding:0.875rem 1rem;cursor:pointer;transition:all 0.2s;}' +
+      '.dd-wm-card:hover{background:rgba(255,255,255,0.06);transform:translateY(-1px);}' +
+      '.dd-wm-card h5{font-size:0.875rem;font-weight:600;color:var(--dd-text);margin:0.35rem 0 0.15rem;}' +
+      '.dd-wm-card p{font-size:0.75rem;color:var(--dd-text-muted);margin:0;}' +
+      '.dd-wm-card-meta{display:flex;justify-content:space-between;font-size:0.6875rem;color:var(--dd-text-dim);margin-top:0.35rem;}' +
+
+      '.dd-wm-badge{display:inline-block;font-size:0.625rem;font-weight:600;padding:0.15rem 0.5rem;border-radius:999px;text-transform:capitalize;}' +
+      '.dd-wm-badge-pending{background:rgba(245,158,11,0.15);color:var(--dd-amber);}' +
+      '.dd-wm-badge-approved{background:rgba(34,197,94,0.15);color:var(--dd-green);}' +
+      '.dd-wm-badge-denied{background:rgba(239,68,68,0.15);color:var(--dd-red);}' +
+      '.dd-wm-badge-executed{background:rgba(139,92,246,0.15);color:#a78bfa;}' +
+      '.dd-wm-badge-expired{background:rgba(100,116,139,0.15);color:var(--dd-text-muted);}' +
+      '.dd-wm-badge-withdrawn{background:rgba(100,116,139,0.15);color:var(--dd-text-muted);}' +
+
+      '@media(max-width:600px){.dd-wm-search-bar{flex-direction:column;}}' +
+    '';
+
+    var style = document.createElement('style');
+    style.id = 'dd-bv-warrant-styles';
+    style.textContent = css;
+    document.head.appendChild(style);
+  }
+
+  function loadWarrants() {
+    var $content = $('#dd-bv-content');
+    wmPage = 0;
+
+    $content.html(
+      '<div class="dd-wm-notice"><i class="fa fa-info-circle"></i> Fire/EMS personnel have view-only access to warrants.</div>' +
+      '<div class="dd-wm-search-bar">' +
+        '<input type="text" class="dd-wm-input" id="dd-wm-name" placeholder="Search by accused name...">' +
+        '<select class="dd-wm-input" id="dd-wm-type" style="flex:0 1 auto;min-width:100px;"><option value="">All Types</option><option value="arrest">Arrest</option><option value="search">Search</option><option value="bench">Bench</option></select>' +
+        '<select class="dd-wm-input" id="dd-wm-status" style="flex:0 1 auto;min-width:110px;"><option value="">All Statuses</option><option value="pending">Pending</option><option value="approved">Approved</option><option value="denied">Denied</option><option value="executed">Executed</option><option value="expired">Expired</option><option value="withdrawn">Withdrawn</option></select>' +
+        '<button class="dd-wm-search-btn" id="dd-wm-search-btn"><i class="fa fa-search"></i> Search</button>' +
+      '</div>' +
+      '<div id="dd-wm-loading" style="display:none;" class="dd-spinner"></div>' +
+      '<div id="dd-wm-empty" style="display:none;" class="dd-empty"><i class="fa fa-gavel"></i><p>No warrants found</p></div>' +
+      '<div id="dd-wm-results" style="display:none;">' +
+        '<div id="dd-wm-cards" class="dd-wm-cards"></div>' +
+        '<div class="dd-bolo-pagination" style="margin-top:0.75rem;">' +
+          '<button class="dd-bolo-page-btn" id="dd-wm-prev" disabled><i class="fa fa-chevron-left"></i> Prev</button>' +
+          '<span class="dd-bolo-page-info" id="dd-wm-page-info">Page 1</span>' +
+          '<button class="dd-bolo-page-btn" id="dd-wm-next">Next <i class="fa fa-chevron-right"></i></button>' +
+        '</div>' +
+      '</div>'
+    );
+
+    // Wire search events
+    $(document).off('click.ddBVWm', '#dd-wm-search-btn').on('click.ddBVWm', '#dd-wm-search-btn', function () { searchWarrants(0); });
+    $(document).off('keydown.ddBVWm', '#dd-wm-name').on('keydown.ddBVWm', '#dd-wm-name', function (e) { if (e.key === 'Enter') searchWarrants(0); });
+    $(document).off('click.ddBVWm', '#dd-wm-prev').on('click.ddBVWm', '#dd-wm-prev', function () { if (wmPage > 0) searchWarrants(wmPage - 1); });
+    $(document).off('click.ddBVWm', '#dd-wm-next').on('click.ddBVWm', '#dd-wm-next', function () { if (wmPage < wmTotalPages - 1) searchWarrants(wmPage + 1); });
+
+    // Auto-search
+    searchWarrants(0);
+  }
+
+  function searchWarrants(page) {
+    wmPage = page;
+    var c = cfg();
+    var params = new URLSearchParams();
+    var name = $('#dd-wm-name').val() || '';
+    var type = $('#dd-wm-type').val() || '';
+    var status = $('#dd-wm-status').val() || '';
+
+    if (name) params.append('name', name);
+    if (type) params.append('warrantType', type);
+    if (status) params.append('status', status);
+    params.append('communityId', c.communityId);
+    params.append('limit', wmLimit);
+    params.append('page', wmPage);
+
+    $('#dd-wm-loading').show();
+    $('#dd-wm-results, #dd-wm-empty').hide();
+
+    $.ajax({
+      url: c.API_URL + '/api/v1/warrants/search?' + params.toString(),
+      method: 'GET',
+      success: function (result) {
+        $('#dd-wm-loading').hide();
+        var warrants = result.data || [];
+        var totalCount = result.totalCount || 0;
+        wmTotalPages = Math.max(1, Math.ceil(totalCount / wmLimit));
+
+        if (!warrants.length) {
+          $('#dd-wm-empty').show();
+          return;
+        }
+
+        $('#dd-wm-results').show();
+        var $cards = $('#dd-wm-cards').empty();
+
+        warrants.forEach(function (w) {
+          var d = w.warrant || {};
+          var chargesPreview = (d.charges || []).slice(0, 2).join(', ');
+          if ((d.charges || []).length > 2) chargesPreview += ' +' + (d.charges.length - 2);
+
+          $cards.append(
+            '<div class="dd-wm-card" data-warrant-id="' + esc(w._id) + '">' +
+              '<div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap;">' +
+                '<span class="dd-wm-badge dd-wm-badge-' + esc(d.status || 'unknown') + '">' + esc(cap(d.status)) + '</span>' +
+                '<span class="dd-wm-badge" style="background:rgba(255,255,255,0.04);color:#64748b;">' + esc(cap(d.warrantType)) + '</span>' +
+              '</div>' +
+              '<h5>' + esc((d.accusedFirstName || '') + ' ' + (d.accusedLastName || '')) + '</h5>' +
+              '<p>' + esc(chargesPreview || 'No charges listed') + '</p>' +
+              '<div class="dd-wm-card-meta"><span>' + fmtDate(d.createdAt) + '</span><span><i class="fa fa-arrow-right" style="font-size:10px;opacity:0.3;"></i></span></div>' +
+            '</div>'
+          );
+        });
+
+        $('#dd-wm-page-info').text('Page ' + (wmPage + 1) + ' of ' + wmTotalPages);
+        $('#dd-wm-prev').prop('disabled', wmPage <= 0);
+        $('#dd-wm-next').prop('disabled', wmPage >= wmTotalPages - 1);
+      },
+      error: function () {
+        $('#dd-wm-loading').hide();
+        $('#dd-wm-empty').show();
+      }
+    });
+  }
+
+  // Warrant detail (read-only overlay)
+  $(document).on('click.ddBV', '.dd-wm-card', function () {
+    var id = $(this).attr('data-warrant-id');
+    if (id) openWarrantDetail(id);
+  });
+
+  function ensureWarrantDetailModal() {
+    if (wmDetailReady) return;
+    wmDetailReady = true;
+
+    var html = '' +
+      '<div class="dd-civ-new-overlay" id="dd-wm-detail-overlay">' +
+        '<div class="dd-civ-new-panel" style="max-width:640px;">' +
+          '<div class="dd-civ-new-header">' +
+            '<span class="dd-civ-new-title" id="dd-wm-detail-title">Warrant Details</span>' +
+            '<button class="dd-civ-close" id="dd-wm-detail-close"><i class="fa fa-times"></i></button>' +
+          '</div>' +
+          '<div class="dd-civ-new-body" id="dd-wm-detail-body"><div class="dd-spinner"></div></div>' +
+        '</div>' +
+      '</div>';
+
+    $('body').append(html);
+    $(document).off('click.ddWMDetail', '#dd-wm-detail-close')
+      .on('click.ddWMDetail', '#dd-wm-detail-close', function () { $('#dd-wm-detail-overlay').removeClass('dd-civ-visible'); });
+    $(document).off('click.ddWMDetail', '#dd-wm-detail-overlay')
+      .on('click.ddWMDetail', '#dd-wm-detail-overlay', function (e) { if (e.target === this) $(this).removeClass('dd-civ-visible'); });
+  }
+
+  function openWarrantDetail(id) {
+    ensureWarrantDetailModal();
+    var $overlay = $('#dd-wm-detail-overlay');
+    var $body = $('#dd-wm-detail-body');
+
+    $body.html('<div class="dd-spinner"></div>');
+    $overlay.addClass('dd-civ-visible');
+
+    var c = cfg();
+    $.ajax({
+      url: c.API_URL + '/api/v1/warrant/' + encodeURIComponent(id),
+      method: 'GET',
+      success: function (w) {
+        var d = w.warrant || {};
+
+        var fields = [
+          { label: 'Warrant Type', val: cap(d.warrantType) },
+          { label: 'Status', val: cap(d.status) },
+          { label: 'Accused', val: (d.accusedFirstName || '') + ' ' + (d.accusedLastName || '') },
+          { label: 'Charges', val: (d.charges || []).join(', ') || 'N/A' },
+          { label: 'Requesting Officer', val: d.requestingOfficerName },
+          { label: 'Judge', val: d.judgeName ? 'The Honorable ' + d.judgeName : 'N/A' },
+          { label: 'Date Filed', val: fmtDate(d.createdAt) }
+        ];
+
+        if (d.warrantType === 'search' && d.searchLocation) {
+          fields.push({ label: 'Search Location', val: d.searchLocation });
+        }
+        if (d.judgeNotes) {
+          fields.push({ label: 'Judge Notes', val: d.judgeNotes });
+        }
+
+        var html = '<div style="text-align:center;margin-bottom:1rem;"><span class="dd-wm-badge dd-wm-badge-' + esc(d.status) + '" style="font-size:0.8125rem;padding:0.35rem 1rem;">' + esc(cap(d.status)) + '</span></div>';
+        html += '<div class="dd-civ-form-grid">';
+        fields.forEach(function (f) {
+          html += '<div class="dd-civ-field"><label>' + esc(f.label) + '</label>' +
+            '<div style="padding:0.5rem 0;color:var(--dd-text);font-size:0.875rem;">' + esc(f.val || 'N/A') + '</div></div>';
+        });
+
+        if (d.probableCause) {
+          html += '<div class="dd-civ-field dd-civ-form-full"><label>Probable Cause</label>' +
+            '<div style="padding:0.75rem;background:rgba(255,255,255,0.02);border:1px solid var(--dd-glass-border);border-radius:8px;color:var(--dd-text);font-size:0.8125rem;line-height:1.65;">' + esc(d.probableCause) + '</div></div>';
+        }
+        html += '</div>';
+
+        // History timeline
+        var history = d.history || [];
+        if (history.length > 0) {
+          var actionLabels = { created: 'Warrant Filed', approved: 'Approved', denied: 'Denied', edited: 'Edited', resubmitted: 'Resubmitted', executed: 'Served', withdrawn: 'Withdrawn' };
+          var actionColors = { created: '#6366f1', approved: '#22c55e', denied: '#ef4444', edited: '#f59e0b', resubmitted: '#f59e0b', executed: '#8b5cf6', withdrawn: '#64748b' };
+
+          html += '<div style="margin-top:1.25rem;padding-top:1rem;border-top:1px solid var(--dd-glass-border);">' +
+            '<div style="font-size:0.75rem;font-weight:600;color:var(--dd-text-muted);margin-bottom:0.75rem;">Warrant History</div>';
+
+          history.forEach(function (h) {
+            var label = actionLabels[h.action] || cap(h.action);
+            var color = actionColors[h.action] || '#64748b';
+            html += '<div style="display:flex;align-items:flex-start;gap:0.75rem;margin-bottom:0.625rem;">' +
+              '<div style="width:8px;height:8px;border-radius:50%;background:' + color + ';margin-top:0.35rem;flex-shrink:0;"></div>' +
+              '<div><div style="font-size:0.8125rem;font-weight:600;color:var(--dd-text);">' + esc(label) + '</div>' +
+              '<div style="font-size:0.6875rem;color:var(--dd-text-muted);">' + esc(h.userName || 'System') + ' &middot; ' + fmtDate(h.timestamp) + '</div>' +
+              (h.notes ? '<div style="font-size:0.75rem;color:var(--dd-text-dim);margin-top:0.15rem;">' + esc(h.notes) + '</div>' : '') +
+              '</div></div>';
+          });
+
+          html += '</div>';
+        }
+
+        $('#dd-wm-detail-title').text(cap(d.warrantType || 'Unknown') + ' Warrant');
+        $body.html(html);
+      },
+      error: function () {
+        $body.html('<p style="color:var(--dd-red);">Failed to load warrant details</p>');
+      }
+    });
+  }
+
+
+  /* ───────────────────────────────────────────
+     Exports
+     ─────────────────────────────────────────── */
+
+  window.ddBoloCreateRender = ddBoloCreateRender;
+  window.ddBoloCreateInit = ddBoloCreateInit;
+  window.ddBoloViewRender = ddBoloViewRender;
+  window.ddBoloViewInit = ddBoloViewInit;
+
+})();

--- a/public/js/dd-ems-personas.js
+++ b/public/js/dd-ems-personas.js
@@ -1,0 +1,659 @@
+/**
+ * Department Dashboard — EMS Personnel Component
+ *
+ * Registers window.ddEmsPersonaRender and window.ddEmsPersonaInit for the
+ * department dashboard component registry. Provides EMS persona listing,
+ * search, creation, editing, and detail viewing.
+ */
+(function () {
+  'use strict';
+
+  /* ───────────────────────────────────────────
+     Helpers & Config
+     ─────────────────────────────────────────── */
+
+  var cfg = function () { return window.ddConfig || {}; };
+  var esc = function (s) { return window.esc ? window.esc(s) : String(s || '').replace(/[&<>"']/g, function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];}); };
+  var toast = function (m, t) { if (window.ddToast) window.ddToast(m, t); };
+
+  var PAGE_SIZE = window.innerWidth <= 600 ? 6 : 12;
+  var ddPage = 0;
+  var ddTotal = 0;
+  var ddData = [];
+  var ddSearchTerm = '';
+  var ddSearchTimer = null;
+  var detailModalReady = false;
+  var newModalReady = false;
+
+  var DEPARTMENTS = ['EMS', 'Fire'];
+
+  /** Flatten API response item */
+  function flatten(item) {
+    if (!item) return null;
+    var p = item.persona || item.details || {};
+    var out = $.extend({}, p);
+    out._id = item._id || item.id || p._id || '';
+    if (out._id && typeof out._id === 'object' && out._id.$oid) {
+      out._id = out._id.$oid;
+    }
+    return out;
+  }
+
+  /** Parse API response */
+  function parseList(data) {
+    var arr = data.personas || data.data || data || [];
+    if (!Array.isArray(arr)) arr = [];
+    return arr.map(flatten).filter(Boolean);
+  }
+
+  /** Build initials from name */
+  function initials(name) {
+    if (!name) return '?';
+    var parts = name.trim().split(/\s+/);
+    if (parts.length >= 2) return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+    return parts[0].substring(0, 2).toUpperCase();
+  }
+
+  /* ───────────────────────────────────────────
+     Inline Styles (<style> injected once)
+     ─────────────────────────────────────────── */
+
+  function injectStyles() {
+    if (document.getElementById('dd-ems-persona-styles')) return;
+
+    var css = '' +
+      /* Toolbar */
+      '.dd-ep-toolbar{display:flex;align-items:center;gap:0.625rem;flex-wrap:wrap;}' +
+      '.dd-ep-search-wrap{position:relative;flex:1;min-width:160px;}' +
+      '.dd-ep-search-wrap i{position:absolute;left:0.625rem;top:50%;transform:translateY(-50%);color:var(--dd-text-dim);font-size:0.75rem;pointer-events:none;}' +
+      '.dd-ep-search{width:100%;padding-left:2rem;background:var(--dd-glass);border:1px solid var(--dd-glass-border);border-radius:var(--dd-radius-sm);padding:0.5rem 0.75rem 0.5rem 2rem;color:var(--dd-text);font-family:inherit;font-size:0.8125rem;outline:none;transition:border-color 0.2s;}' +
+      '.dd-ep-search:focus{border-color:rgba(255,255,255,0.15);}' +
+      '.dd-ep-search::placeholder{color:var(--dd-text-dim);}' +
+
+      /* Add button */
+      '.dd-ep-add-btn{padding:0.5rem 0.875rem;border-radius:var(--dd-radius-sm);border:1px solid rgba(59,130,246,0.25);background:rgba(59,130,246,0.1);color:#93c5fd;font-family:inherit;font-size:0.75rem;font-weight:500;cursor:pointer;transition:all 0.2s;white-space:nowrap;display:inline-flex;align-items:center;gap:0.375rem;}' +
+      '.dd-ep-add-btn:hover{background:rgba(59,130,246,0.18);border-color:rgba(59,130,246,0.4);color:#bfdbfe;}' +
+
+      /* Grid */
+      '.dd-ep-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:0.75rem;}' +
+
+      /* Card */
+      '.dd-ep-card{background:var(--dd-glass);border:1px solid var(--dd-glass-border);border-radius:var(--dd-radius);padding:1rem;cursor:pointer;transition:all 0.2s;display:flex;align-items:flex-start;gap:0.75rem;}' +
+      '.dd-ep-card:hover{background:rgba(255,255,255,0.06);border-color:rgba(255,255,255,0.12);transform:translateY(-2px);}' +
+      '.dd-ep-avatar{width:44px;height:44px;border-radius:50%;flex-shrink:0;display:flex;align-items:center;justify-content:center;font-size:0.8125rem;font-weight:700;color:#fff;background:var(--dd-blue);}' +
+      '.dd-ep-info{flex:1;min-width:0;}' +
+      '.dd-ep-name{font-size:0.875rem;font-weight:600;color:var(--dd-text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}' +
+      '.dd-ep-meta{font-size:0.75rem;color:var(--dd-text-muted);margin-top:0.15rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}' +
+      '.dd-ep-dept-badge{display:inline-block;font-size:0.625rem;font-weight:600;padding:0.15rem 0.5rem;border-radius:999px;text-transform:uppercase;letter-spacing:0.04em;margin-top:0.35rem;}' +
+      '.dd-ep-dept-ems{background:rgba(34,197,94,0.15);color:var(--dd-green);}' +
+      '.dd-ep-dept-fire{background:rgba(249,115,22,0.15);color:#fb923c;}' +
+
+      /* Pagination */
+      '.dd-ep-pagination{display:flex;align-items:center;justify-content:center;gap:0.75rem;margin-top:1rem;}' +
+      '.dd-ep-page-info{font-size:0.75rem;color:var(--dd-text-muted);}' +
+      '.dd-ep-page-btn{background:var(--dd-glass);border:1px solid var(--dd-glass-border);border-radius:var(--dd-radius);color:var(--dd-text);padding:0.35rem 0.75rem;font-size:0.75rem;cursor:pointer;transition:all 0.2s;font-family:inherit;}' +
+      '.dd-ep-page-btn:hover:not(:disabled){background:rgba(255,255,255,0.06);border-color:rgba(255,255,255,0.12);}' +
+      '.dd-ep-page-btn:disabled{opacity:0.35;cursor:default;}' +
+
+      /* Responsive */
+      '@media(max-width:600px){' +
+        '.dd-ep-toolbar{flex-direction:column;align-items:stretch;}' +
+        '.dd-ep-search-wrap{min-width:0;}' +
+      '}' +
+    '';
+
+    var style = document.createElement('style');
+    style.id = 'dd-ems-persona-styles';
+    style.textContent = css;
+    document.head.appendChild(style);
+  }
+
+  /* ───────────────────────────────────────────
+     Render Function (returns HTML string)
+     ─────────────────────────────────────────── */
+
+  function ddEmsPersonaRender(/* key */) {
+    return '' +
+      '<div class="dd-card-header">' +
+        '<div class="dd-card-header-left">' +
+          '<div class="dd-card-icon" style="background:rgba(59,130,246,0.15);color:var(--dd-blue);"><i class="fa fa-id-badge"></i></div>' +
+          '<div><h3 class="dd-card-title">Personnel</h3><p class="dd-card-subtitle">Manage EMS/Fire personnel</p></div>' +
+        '</div>' +
+      '</div>' +
+      '<div class="dd-card-body">' +
+        '<div class="dd-ep-toolbar" style="margin-bottom:0.875rem;">' +
+          '<div class="dd-ep-search-wrap">' +
+            '<i class="fa fa-search"></i>' +
+            '<input type="text" class="dd-ep-search" id="dd-ep-search" placeholder="Search personnel..." autocomplete="off">' +
+          '</div>' +
+          '<button class="dd-ep-add-btn" id="dd-ep-add-btn"><i class="fa fa-plus"></i> Add Personnel</button>' +
+        '</div>' +
+        '<div class="dd-ep-loading dd-spinner"></div>' +
+        '<div class="dd-ep-empty-state dd-empty" style="display:none;">' +
+          '<div class="dd-empty-icon-wrap" style="background:rgba(59,130,246,0.08);border-color:rgba(59,130,246,0.15);">' +
+            '<i class="fa fa-id-badge" style="color:var(--dd-blue);"></i>' +
+          '</div>' +
+          '<p class="dd-empty-title">No personnel found</p>' +
+          '<p class="dd-empty-sub">Create your first personnel to get started</p>' +
+        '</div>' +
+        '<div id="dd-ep-grid" class="dd-ep-grid" style="display:none;"></div>' +
+        '<div class="dd-ep-pagination" id="dd-ep-pagination" style="display:none;">' +
+          '<button class="dd-ep-page-btn" id="dd-ep-prev"><i class="fa fa-chevron-left"></i> Prev</button>' +
+          '<span class="dd-ep-page-info" id="dd-ep-page-info">Page 1</span>' +
+          '<button class="dd-ep-page-btn" id="dd-ep-next">Next <i class="fa fa-chevron-right"></i></button>' +
+        '</div>' +
+      '</div>';
+  }
+
+  /* ───────────────────────────────────────────
+     Init Function
+     ─────────────────────────────────────────── */
+
+  function ddEmsPersonaInit() {
+    injectStyles();
+    ddPage = 0;
+    ddSearchTerm = '';
+    wireEvents();
+    loadPersonas();
+  }
+
+  /* ───────────────────────────────────────────
+     Event Wiring
+     ─────────────────────────────────────────── */
+
+  function wireEvents() {
+    $(document)
+      .off('input.ddEP', '#dd-ep-search')
+      .on('input.ddEP', '#dd-ep-search', function () {
+        clearTimeout(ddSearchTimer);
+        var val = $(this).val().trim();
+        ddSearchTimer = setTimeout(function () {
+          ddSearchTerm = val;
+          ddPage = 0;
+          loadPersonas();
+        }, 300);
+      });
+
+    $(document)
+      .off('click.ddEP', '#dd-ep-prev')
+      .on('click.ddEP', '#dd-ep-prev', function () {
+        if (ddPage > 0) { ddPage--; loadPersonas(); }
+      });
+
+    $(document)
+      .off('click.ddEP', '#dd-ep-next')
+      .on('click.ddEP', '#dd-ep-next', function () {
+        if ((ddPage + 1) * PAGE_SIZE < ddTotal) { ddPage++; loadPersonas(); }
+      });
+
+    $(document)
+      .off('click.ddEP', '#dd-ep-add-btn')
+      .on('click.ddEP', '#dd-ep-add-btn', function () {
+        openNewModal();
+      });
+
+    $(document)
+      .off('click.ddEP', '.dd-ep-card')
+      .on('click.ddEP', '.dd-ep-card', function () {
+        var id = $(this).attr('data-ep-id');
+        if (id) openDetailModal(id);
+      });
+  }
+
+  /* ───────────────────────────────────────────
+     Data Loading
+     ─────────────────────────────────────────── */
+
+  function loadPersonas() {
+    var c = cfg();
+    var $grid = $('#dd-ep-grid');
+    var $loading = $('.dd-ep-loading');
+    var $empty = $('.dd-ep-empty-state');
+    var $pagination = $('#dd-ep-pagination');
+
+    $grid.hide();
+    $empty.hide();
+    $pagination.hide();
+    $loading.show();
+
+    var url = c.API_URL + '/api/v1/ems-personas' +
+      '?active_community_id=' + encodeURIComponent(c.communityId) +
+      '&user_id=' + encodeURIComponent(c.userId) +
+      '&limit=' + PAGE_SIZE +
+      '&page=' + ddPage;
+
+    if (ddSearchTerm) {
+      url += '&search=' + encodeURIComponent(ddSearchTerm);
+    }
+
+    $.ajax({
+      url: url,
+      method: 'GET',
+      success: function (data) {
+        $loading.hide();
+        ddData = parseList(data);
+        ddTotal = (data && data.totalCount != null) ? data.totalCount :
+                  (data && data.pagination && data.pagination.totalCount != null) ? data.pagination.totalCount :
+                  (ddData.length < PAGE_SIZE ? (ddPage * PAGE_SIZE + ddData.length) : -1);
+        renderGrid();
+      },
+      error: function () {
+        $loading.hide();
+        ddData = [];
+        renderGrid();
+        toast('Failed to load personnel', 'error');
+      }
+    });
+  }
+
+  /* ───────────────────────────────────────────
+     Grid Rendering
+     ─────────────────────────────────────────── */
+
+  function renderGrid() {
+    var $grid = $('#dd-ep-grid');
+    var $empty = $('.dd-ep-empty-state');
+    $grid.empty();
+
+    if (!ddData.length) {
+      $grid.hide();
+      $empty.find('.dd-empty-title').text(ddSearchTerm ? 'No results found' : 'No personnel yet');
+      $empty.find('.dd-empty-sub').text(ddSearchTerm ? 'Try a different search term' : 'Create your first personnel to get started');
+      $empty.show();
+      updatePagination();
+      return;
+    }
+
+    $empty.hide();
+    $grid.show();
+
+    ddData.forEach(function (p) {
+      var name = esc((p.firstName || '') + ' ' + (p.lastName || '')).trim() || 'Unknown';
+      var dept = (p.department || 'EMS').toLowerCase();
+      var deptCls = dept === 'fire' ? 'dd-ep-dept-fire' : 'dd-ep-dept-ems';
+
+      var meta = [];
+      if (p.callSign) meta.push('CS: ' + esc(p.callSign));
+      if (p.station) meta.push('Stn: ' + esc(p.station));
+      if (p.assignmentArea) meta.push(esc(p.assignmentArea));
+
+      var html = '' +
+        '<div class="dd-ep-card" data-ep-id="' + esc(p._id) + '">' +
+          '<div class="dd-ep-avatar">' + initials(name) + '</div>' +
+          '<div class="dd-ep-info">' +
+            '<div class="dd-ep-name">' + name + '</div>' +
+            '<div class="dd-ep-meta">' + (meta.join(' &middot; ') || 'No details') + '</div>' +
+            '<span class="dd-ep-dept-badge ' + deptCls + '">' + esc(p.department || 'EMS') + '</span>' +
+          '</div>' +
+        '</div>';
+
+      $grid.append(html);
+    });
+
+    updatePagination();
+  }
+
+  function updatePagination() {
+    var $pagination = $('#dd-ep-pagination');
+    var $info = $('#dd-ep-page-info');
+    var $prev = $('#dd-ep-prev');
+    var $next = $('#dd-ep-next');
+
+    if (ddTotal <= PAGE_SIZE && ddPage === 0) {
+      $pagination.hide();
+      return;
+    }
+
+    $pagination.show();
+    var totalPages = ddTotal > 0 ? Math.ceil(ddTotal / PAGE_SIZE) : ddPage + 2;
+    $info.text('Page ' + (ddPage + 1) + (ddTotal > 0 ? ' of ' + totalPages : ''));
+    $prev.prop('disabled', ddPage <= 0);
+    $next.prop('disabled', ddTotal > 0 ? (ddPage + 1) * PAGE_SIZE >= ddTotal : ddData.length < PAGE_SIZE);
+  }
+
+  /* ───────────────────────────────────────────
+     Detail Modal
+     ─────────────────────────────────────────── */
+
+  function ensureDetailModal() {
+    if (detailModalReady) return;
+    detailModalReady = true;
+
+    var html = '' +
+      '<div class="dd-civ-new-overlay" id="dd-ep-detail-overlay">' +
+        '<div class="dd-civ-new-panel" style="max-width:560px;">' +
+          '<div class="dd-civ-new-header">' +
+            '<span class="dd-civ-new-title" id="dd-ep-detail-title">Personnel Details</span>' +
+            '<button class="dd-civ-close" id="dd-ep-detail-close"><i class="fa fa-times"></i></button>' +
+          '</div>' +
+          '<div class="dd-civ-new-body" id="dd-ep-detail-body">' +
+            '<div class="dd-spinner"></div>' +
+          '</div>' +
+          '<div class="dd-civ-new-footer" id="dd-ep-detail-footer"></div>' +
+        '</div>' +
+      '</div>';
+
+    $('body').append(html);
+
+    $(document).off('click.ddEPDetail', '#dd-ep-detail-close')
+      .on('click.ddEPDetail', '#dd-ep-detail-close', closeDetailModal);
+    $(document).off('click.ddEPDetail', '#dd-ep-detail-overlay')
+      .on('click.ddEPDetail', '#dd-ep-detail-overlay', function (e) {
+        if (e.target === this) closeDetailModal();
+      });
+  }
+
+  function openDetailModal(id) {
+    ensureDetailModal();
+    var $overlay = $('#dd-ep-detail-overlay');
+    var $body = $('#dd-ep-detail-body');
+    var $footer = $('#dd-ep-detail-footer');
+
+    $body.html('<div class="dd-spinner"></div>');
+    $footer.empty();
+    $overlay.addClass('dd-civ-visible');
+
+    var c = cfg();
+    $.ajax({
+      url: c.API_URL + '/api/v1/ems-personas/' + encodeURIComponent(id),
+      method: 'GET',
+      success: function (data) {
+        var p = data.persona || data || {};
+
+        var fields = [
+          { label: 'First Name', val: p.firstName },
+          { label: 'Last Name', val: p.lastName },
+          { label: 'Department', val: p.department },
+          { label: 'Assignment Area', val: p.assignmentArea },
+          { label: 'Station', val: p.station },
+          { label: 'Call Sign', val: p.callSign }
+        ];
+
+        var html = '<div class="dd-civ-form-grid">';
+        fields.forEach(function (f) {
+          html += '<div class="dd-civ-field"><label>' + esc(f.label) + '</label>' +
+            '<div style="padding:0.5rem 0;color:var(--dd-text);font-size:0.875rem;">' + esc(f.val || 'N/A') + '</div></div>';
+        });
+        html += '</div>';
+
+        $('#dd-ep-detail-title').text((p.firstName || '') + ' ' + (p.lastName || ''));
+        $body.html(html);
+        $footer.html(
+          '<button class="dd-civ-btn dd-civ-btn-primary dd-civ-btn-small" id="dd-ep-edit-btn" data-id="' + esc(id) + '"><i class="fa fa-edit"></i> Edit</button>' +
+          '<button class="dd-civ-btn dd-civ-btn-danger dd-civ-btn-small" id="dd-ep-delete-btn" data-id="' + esc(id) + '"><i class="fa fa-trash"></i> Delete</button>'
+        );
+      },
+      error: function () {
+        $body.html('<p style="color:var(--dd-red);">Failed to load details</p>');
+        toast('Failed to load personnel details', 'error');
+      }
+    });
+  }
+
+  function closeDetailModal() {
+    $('#dd-ep-detail-overlay').removeClass('dd-civ-visible');
+  }
+
+  // Edit button in detail modal
+  $(document).on('click.ddEP', '#dd-ep-edit-btn', function () {
+    var id = $(this).attr('data-id');
+    closeDetailModal();
+    openEditModal(id);
+  });
+
+  // Delete button in detail modal
+  $(document).on('click.ddEP', '#dd-ep-delete-btn', function () {
+    var id = $(this).attr('data-id');
+    if (window.ddModal) {
+      window.ddModal({
+        title: 'Delete Personnel',
+        message: 'Are you sure you want to delete this personnel? This action cannot be undone.',
+        confirmLabel: 'Delete',
+        confirmClass: 'dd-civ-btn-danger',
+        onConfirm: function () { deletePersona(id); }
+      });
+    } else {
+      if (confirm('Delete this personnel?')) deletePersona(id);
+    }
+  });
+
+  /* ───────────────────────────────────────────
+     New Personnel Modal
+     ─────────────────────────────────────────── */
+
+  function ensureNewModal() {
+    if (newModalReady) return;
+    newModalReady = true;
+
+    var deptOptions = DEPARTMENTS.map(function (d) {
+      return '<option value="' + esc(d) + '">' + esc(d) + '</option>';
+    }).join('');
+
+    var html = '' +
+      '<div class="dd-civ-new-overlay" id="dd-ep-new-overlay">' +
+        '<div class="dd-civ-new-panel" style="max-width:560px;">' +
+          '<div class="dd-civ-new-header">' +
+            '<span class="dd-civ-new-title">New Personnel</span>' +
+            '<button class="dd-civ-close" id="dd-ep-new-close"><i class="fa fa-times"></i></button>' +
+          '</div>' +
+          '<div class="dd-civ-new-body">' +
+            '<div class="dd-civ-form-grid">' +
+              '<div class="dd-civ-field"><label>First Name *</label><input type="text" id="dd-ep-new-firstName" maxlength="50" placeholder="First name"></div>' +
+              '<div class="dd-civ-field"><label>Last Name *</label><input type="text" id="dd-ep-new-lastName" maxlength="50" placeholder="Last name"></div>' +
+              '<div class="dd-civ-field"><label>Department *</label><select id="dd-ep-new-dept">' + deptOptions + '</select></div>' +
+              '<div class="dd-civ-field"><label>Assignment Area *</label><input type="text" id="dd-ep-new-area" maxlength="50" placeholder="e.g. Downtown"></div>' +
+              '<div class="dd-civ-field"><label>Station</label><input type="text" id="dd-ep-new-station" maxlength="5" placeholder="e.g. 42"></div>' +
+              '<div class="dd-civ-field"><label>Call Sign</label><input type="text" id="dd-ep-new-callSign" maxlength="10" placeholder="e.g. M-12"></div>' +
+            '</div>' +
+          '</div>' +
+          '<div class="dd-civ-new-footer">' +
+            '<button class="dd-civ-btn dd-civ-btn-secondary" id="dd-ep-new-cancel">Cancel</button>' +
+            '<button class="dd-civ-btn dd-civ-btn-primary" id="dd-ep-new-save"><i class="fa fa-plus"></i> Create</button>' +
+          '</div>' +
+        '</div>' +
+      '</div>';
+
+    $('body').append(html);
+
+    $(document).off('click.ddEPNew', '#dd-ep-new-close, #dd-ep-new-cancel')
+      .on('click.ddEPNew', '#dd-ep-new-close, #dd-ep-new-cancel', closeNewModal);
+    $(document).off('click.ddEPNew', '#dd-ep-new-overlay')
+      .on('click.ddEPNew', '#dd-ep-new-overlay', function (e) {
+        if (e.target === this) closeNewModal();
+      });
+    $(document).off('click.ddEPNew', '#dd-ep-new-save')
+      .on('click.ddEPNew', '#dd-ep-new-save', createPersona);
+  }
+
+  function openNewModal() {
+    ensureNewModal();
+    // Clear form
+    $('#dd-ep-new-firstName').val('');
+    $('#dd-ep-new-lastName').val('');
+    $('#dd-ep-new-dept').val('EMS');
+    $('#dd-ep-new-area').val('');
+    $('#dd-ep-new-station').val('');
+    $('#dd-ep-new-callSign').val('');
+    $('#dd-ep-new-save').prop('disabled', false).html('<i class="fa fa-plus"></i> Create');
+    $('#dd-ep-new-overlay').addClass('dd-civ-visible');
+  }
+
+  function closeNewModal() {
+    $('#dd-ep-new-overlay').removeClass('dd-civ-visible');
+  }
+
+  function createPersona() {
+    var firstName = $('#dd-ep-new-firstName').val().trim();
+    var lastName = $('#dd-ep-new-lastName').val().trim();
+    var department = $('#dd-ep-new-dept').val();
+    var assignmentArea = $('#dd-ep-new-area').val().trim();
+    var station = $('#dd-ep-new-station').val().trim();
+    var callSign = $('#dd-ep-new-callSign').val().trim();
+    var c = cfg();
+
+    if (!firstName || !lastName || !department || !assignmentArea) {
+      toast('Please fill in all required fields', 'error');
+      return;
+    }
+
+    if (assignmentArea.length > 50) { toast('Assignment area must be 50 characters or less', 'error'); return; }
+    if (station && station.length > 5) { toast('Station must be 5 characters or less', 'error'); return; }
+    if (callSign && callSign.length > 10) { toast('Call sign must be 10 characters or less', 'error'); return; }
+
+    var $btn = $('#dd-ep-new-save');
+    $btn.prop('disabled', true).html('<i class="fa fa-spinner fa-spin"></i> Creating...');
+
+    $.ajax({
+      url: c.API_URL + '/api/v1/ems-personas',
+      method: 'POST',
+      contentType: 'application/json',
+      data: JSON.stringify({
+        persona: {
+          firstName: firstName,
+          lastName: lastName,
+          department: department,
+          assignmentArea: assignmentArea,
+          station: station || undefined,
+          callSign: callSign || undefined,
+          activeCommunityID: c.communityId,
+          userID: c.userId
+        }
+      }),
+      success: function () {
+        toast('Personnel created successfully', 'success');
+        closeNewModal();
+        ddPage = 0;
+        loadPersonas();
+      },
+      error: function (xhr) {
+        var msg = 'Failed to create personnel';
+        try { msg = JSON.parse(xhr.responseText).error || msg; } catch (e) {}
+        toast(msg, 'error');
+      },
+      complete: function () {
+        $btn.prop('disabled', false).html('<i class="fa fa-plus"></i> Create');
+      }
+    });
+  }
+
+  /* ───────────────────────────────────────────
+     Edit Modal
+     ─────────────────────────────────────────── */
+
+  function openEditModal(id) {
+    ensureNewModal(); // reuse the same modal structure
+    var c = cfg();
+    var $overlay = $('#dd-ep-new-overlay');
+
+    // Show loading
+    $overlay.addClass('dd-civ-visible');
+    $('#dd-ep-new-save').prop('disabled', true).html('<i class="fa fa-spinner fa-spin"></i>');
+
+    $.ajax({
+      url: c.API_URL + '/api/v1/ems-personas/' + encodeURIComponent(id),
+      method: 'GET',
+      success: function (data) {
+        var p = data.persona || data || {};
+        $('#dd-ep-new-firstName').val(p.firstName || '');
+        $('#dd-ep-new-lastName').val(p.lastName || '');
+        $('#dd-ep-new-dept').val(p.department || 'EMS');
+        $('#dd-ep-new-area').val(p.assignmentArea || '');
+        $('#dd-ep-new-station').val(p.station || '');
+        $('#dd-ep-new-callSign').val(p.callSign || '');
+
+        // Switch save button to update mode
+        var $btn = $('#dd-ep-new-save');
+        $btn.prop('disabled', false).html('<i class="fa fa-save"></i> Update');
+        $btn.off('click.ddEPNew').on('click.ddEPNew', function () { updatePersona(id); });
+        $('.dd-civ-new-title', $overlay.find('.dd-civ-new-panel')).text('Edit Personnel');
+      },
+      error: function () {
+        toast('Failed to load personnel for editing', 'error');
+        closeNewModal();
+      }
+    });
+  }
+
+  function updatePersona(id) {
+    var firstName = $('#dd-ep-new-firstName').val().trim();
+    var lastName = $('#dd-ep-new-lastName').val().trim();
+    var department = $('#dd-ep-new-dept').val();
+    var assignmentArea = $('#dd-ep-new-area').val().trim();
+    var station = $('#dd-ep-new-station').val().trim();
+    var callSign = $('#dd-ep-new-callSign').val().trim();
+    var c = cfg();
+
+    if (!firstName || !lastName || !department || !assignmentArea) {
+      toast('Please fill in all required fields', 'error');
+      return;
+    }
+
+    if (assignmentArea.length > 50) { toast('Assignment area must be 50 characters or less', 'error'); return; }
+    if (station && station.length > 5) { toast('Station must be 5 characters or less', 'error'); return; }
+    if (callSign && callSign.length > 10) { toast('Call sign must be 10 characters or less', 'error'); return; }
+
+    var $btn = $('#dd-ep-new-save');
+    $btn.prop('disabled', true).html('<i class="fa fa-spinner fa-spin"></i> Updating...');
+
+    $.ajax({
+      url: c.API_URL + '/api/v1/ems-personas/' + encodeURIComponent(id),
+      method: 'PUT',
+      contentType: 'application/json',
+      data: JSON.stringify({
+        persona: {
+          firstName: firstName,
+          lastName: lastName,
+          department: department,
+          assignmentArea: assignmentArea,
+          station: station || undefined,
+          callSign: callSign || undefined,
+          activeCommunityID: c.communityId,
+          userID: c.userId
+        }
+      }),
+      success: function () {
+        toast('Personnel updated successfully', 'success');
+        closeNewModal();
+        // Rebind the save button to create mode
+        $(document).off('click.ddEPNew', '#dd-ep-new-save').on('click.ddEPNew', '#dd-ep-new-save', createPersona);
+        loadPersonas();
+      },
+      error: function (xhr) {
+        var msg = 'Failed to update personnel';
+        try { msg = JSON.parse(xhr.responseText).error || msg; } catch (e) {}
+        toast(msg, 'error');
+      },
+      complete: function () {
+        $btn.prop('disabled', false).html('<i class="fa fa-save"></i> Update');
+      }
+    });
+  }
+
+  /* ───────────────────────────────────────────
+     Delete
+     ─────────────────────────────────────────── */
+
+  function deletePersona(id) {
+    var c = cfg();
+    $.ajax({
+      url: c.API_URL + '/api/v1/ems-personas/' + encodeURIComponent(id),
+      method: 'DELETE',
+      success: function () {
+        toast('Personnel deleted successfully', 'success');
+        closeDetailModal();
+        loadPersonas();
+      },
+      error: function () {
+        toast('Failed to delete personnel', 'error');
+      }
+    });
+  }
+
+  /* ───────────────────────────────────────────
+     Exports
+     ─────────────────────────────────────────── */
+
+  window.ddEmsPersonaRender = ddEmsPersonaRender;
+  window.ddEmsPersonaInit = ddEmsPersonaInit;
+
+})();

--- a/public/js/dd-ems-vehicles.js
+++ b/public/js/dd-ems-vehicles.js
@@ -1,0 +1,645 @@
+/**
+ * Department Dashboard — EMS Vehicles Component
+ *
+ * Registers window.ddEmsVehRender and window.ddEmsVehInit for the
+ * department dashboard component registry. Provides EMS vehicle listing,
+ * creation, editing, and detail viewing.
+ */
+(function () {
+  'use strict';
+
+  /* ───────────────────────────────────────────
+     Helpers & Config
+     ─────────────────────────────────────────── */
+
+  var cfg = function () { return window.ddConfig || {}; };
+  var esc = function (s) { return window.esc ? window.esc(s) : String(s || '').replace(/[&<>"']/g, function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];}); };
+  var toast = function (m, t) { if (window.ddToast) window.ddToast(m, t); };
+
+  var PAGE_SIZE = window.innerWidth <= 600 ? 6 : 12;
+  var ddPage = 0;
+  var ddTotal = 0;
+  var ddData = [];
+  var ddSearchTerm = '';
+  var ddSearchTimer = null;
+  var detailModalReady = false;
+  var newModalReady = false;
+
+  var VEHICLE_MODELS = [
+    'FireTruck',
+    'Fire Dept. Vehicle',
+    'Fire Dept. Chief Vehicle',
+    'Ambulance',
+    'Medical Dept. Vehicle',
+    'Medical Dept. Chief Vehicle',
+    'LifeGuard Patrol Vehicle',
+    'LifeGuard Boat'
+  ];
+
+  /** Flatten API response item */
+  function flatten(item) {
+    if (!item) return null;
+    var v = item.vehicle || item.details || {};
+    var out = $.extend({}, v);
+    out._id = item._id || item.id || v._id || '';
+    if (out._id && typeof out._id === 'object' && out._id.$oid) {
+      out._id = out._id.$oid;
+    }
+    return out;
+  }
+
+  /** Parse API response */
+  function parseList(data) {
+    var arr = data.vehicles || data.data || data || [];
+    if (!Array.isArray(arr)) arr = [];
+    return arr.map(flatten).filter(Boolean);
+  }
+
+  /* ───────────────────────────────────────────
+     Inline Styles
+     ─────────────────────────────────────────── */
+
+  function injectStyles() {
+    if (document.getElementById('dd-ems-veh-styles')) return;
+
+    var css = '' +
+      /* Toolbar */
+      '.dd-ev-toolbar{display:flex;align-items:center;gap:0.625rem;flex-wrap:wrap;}' +
+      '.dd-ev-search-wrap{position:relative;flex:1;min-width:160px;}' +
+      '.dd-ev-search-wrap i{position:absolute;left:0.625rem;top:50%;transform:translateY(-50%);color:var(--dd-text-dim);font-size:0.75rem;pointer-events:none;}' +
+      '.dd-ev-search{width:100%;padding-left:2rem;background:var(--dd-glass);border:1px solid var(--dd-glass-border);border-radius:var(--dd-radius-sm);padding:0.5rem 0.75rem 0.5rem 2rem;color:var(--dd-text);font-family:inherit;font-size:0.8125rem;outline:none;transition:border-color 0.2s;}' +
+      '.dd-ev-search:focus{border-color:rgba(255,255,255,0.15);}' +
+      '.dd-ev-search::placeholder{color:var(--dd-text-dim);}' +
+
+      /* Add button */
+      '.dd-ev-add-btn{padding:0.5rem 0.875rem;border-radius:var(--dd-radius-sm);border:1px solid rgba(34,197,94,0.25);background:rgba(34,197,94,0.1);color:#86efac;font-family:inherit;font-size:0.75rem;font-weight:500;cursor:pointer;transition:all 0.2s;white-space:nowrap;display:inline-flex;align-items:center;gap:0.375rem;}' +
+      '.dd-ev-add-btn:hover{background:rgba(34,197,94,0.18);border-color:rgba(34,197,94,0.4);color:#bbf7d0;}' +
+
+      /* Grid */
+      '.dd-ev-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:0.75rem;}' +
+
+      /* Card */
+      '.dd-ev-card{background:var(--dd-glass);border:1px solid var(--dd-glass-border);border-radius:var(--dd-radius);padding:1rem;cursor:pointer;transition:all 0.2s;display:flex;align-items:flex-start;gap:0.75rem;}' +
+      '.dd-ev-card:hover{background:rgba(255,255,255,0.06);border-color:rgba(255,255,255,0.12);transform:translateY(-2px);}' +
+      '.dd-ev-icon{width:44px;height:44px;border-radius:var(--dd-radius-sm);flex-shrink:0;display:flex;align-items:center;justify-content:center;font-size:1rem;color:#fff;background:linear-gradient(135deg,rgba(34,197,94,0.2),rgba(34,197,94,0.1));}' +
+      '.dd-ev-info{flex:1;min-width:0;}' +
+      '.dd-ev-name{font-size:0.875rem;font-weight:600;color:var(--dd-text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}' +
+      '.dd-ev-meta{font-size:0.75rem;color:var(--dd-text-muted);margin-top:0.15rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}' +
+      '.dd-ev-plate{display:inline-block;font-size:0.625rem;font-weight:700;padding:0.2rem 0.5rem;border-radius:4px;background:rgba(255,255,255,0.08);color:var(--dd-text);letter-spacing:0.05em;margin-top:0.35rem;border:1px solid var(--dd-glass-border);}' +
+
+      /* Pagination */
+      '.dd-ev-pagination{display:flex;align-items:center;justify-content:center;gap:0.75rem;margin-top:1rem;}' +
+      '.dd-ev-page-info{font-size:0.75rem;color:var(--dd-text-muted);}' +
+      '.dd-ev-page-btn{background:var(--dd-glass);border:1px solid var(--dd-glass-border);border-radius:var(--dd-radius);color:var(--dd-text);padding:0.35rem 0.75rem;font-size:0.75rem;cursor:pointer;transition:all 0.2s;font-family:inherit;}' +
+      '.dd-ev-page-btn:hover:not(:disabled){background:rgba(255,255,255,0.06);border-color:rgba(255,255,255,0.12);}' +
+      '.dd-ev-page-btn:disabled{opacity:0.35;cursor:default;}' +
+
+      /* Responsive */
+      '@media(max-width:600px){' +
+        '.dd-ev-toolbar{flex-direction:column;align-items:stretch;}' +
+        '.dd-ev-search-wrap{min-width:0;}' +
+      '}' +
+    '';
+
+    var style = document.createElement('style');
+    style.id = 'dd-ems-veh-styles';
+    style.textContent = css;
+    document.head.appendChild(style);
+  }
+
+  /* ───────────────────────────────────────────
+     Render Function
+     ─────────────────────────────────────────── */
+
+  function ddEmsVehRender(/* key */) {
+    return '' +
+      '<div class="dd-card-header">' +
+        '<div class="dd-card-header-left">' +
+          '<div class="dd-card-icon" style="background:rgba(34,197,94,0.15);color:var(--dd-green);"><i class="fa fa-ambulance"></i></div>' +
+          '<div><h3 class="dd-card-title">Vehicles</h3><p class="dd-card-subtitle">Manage EMS/Fire vehicles</p></div>' +
+        '</div>' +
+      '</div>' +
+      '<div class="dd-card-body">' +
+        '<div class="dd-ev-toolbar" style="margin-bottom:0.875rem;">' +
+          '<div class="dd-ev-search-wrap">' +
+            '<i class="fa fa-search"></i>' +
+            '<input type="text" class="dd-ev-search" id="dd-ev-search" placeholder="Search vehicles..." autocomplete="off">' +
+          '</div>' +
+          '<button class="dd-ev-add-btn" id="dd-ev-add-btn"><i class="fa fa-plus"></i> Add Vehicle</button>' +
+        '</div>' +
+        '<div class="dd-ev-loading dd-spinner"></div>' +
+        '<div class="dd-ev-empty-state dd-empty" style="display:none;">' +
+          '<div class="dd-empty-icon-wrap" style="background:rgba(34,197,94,0.08);border-color:rgba(34,197,94,0.15);">' +
+            '<i class="fa fa-ambulance" style="color:var(--dd-green);"></i>' +
+          '</div>' +
+          '<p class="dd-empty-title">No vehicles found</p>' +
+          '<p class="dd-empty-sub">Create your first vehicle to get started</p>' +
+        '</div>' +
+        '<div id="dd-ev-grid" class="dd-ev-grid" style="display:none;"></div>' +
+        '<div class="dd-ev-pagination" id="dd-ev-pagination" style="display:none;">' +
+          '<button class="dd-ev-page-btn" id="dd-ev-prev"><i class="fa fa-chevron-left"></i> Prev</button>' +
+          '<span class="dd-ev-page-info" id="dd-ev-page-info">Page 1</span>' +
+          '<button class="dd-ev-page-btn" id="dd-ev-next">Next <i class="fa fa-chevron-right"></i></button>' +
+        '</div>' +
+      '</div>';
+  }
+
+  /* ───────────────────────────────────────────
+     Init Function
+     ─────────────────────────────────────────── */
+
+  function ddEmsVehInit() {
+    injectStyles();
+    ddPage = 0;
+    ddSearchTerm = '';
+    wireEvents();
+    loadVehicles();
+  }
+
+  /* ───────────────────────────────────────────
+     Event Wiring
+     ─────────────────────────────────────────── */
+
+  function wireEvents() {
+    $(document)
+      .off('input.ddEV', '#dd-ev-search')
+      .on('input.ddEV', '#dd-ev-search', function () {
+        clearTimeout(ddSearchTimer);
+        var val = $(this).val().trim();
+        ddSearchTimer = setTimeout(function () {
+          ddSearchTerm = val;
+          ddPage = 0;
+          loadVehicles();
+        }, 300);
+      });
+
+    $(document)
+      .off('click.ddEV', '#dd-ev-prev')
+      .on('click.ddEV', '#dd-ev-prev', function () {
+        if (ddPage > 0) { ddPage--; loadVehicles(); }
+      });
+
+    $(document)
+      .off('click.ddEV', '#dd-ev-next')
+      .on('click.ddEV', '#dd-ev-next', function () {
+        if ((ddPage + 1) * PAGE_SIZE < ddTotal) { ddPage++; loadVehicles(); }
+      });
+
+    $(document)
+      .off('click.ddEV', '#dd-ev-add-btn')
+      .on('click.ddEV', '#dd-ev-add-btn', function () {
+        openNewModal();
+      });
+
+    $(document)
+      .off('click.ddEV', '.dd-ev-card')
+      .on('click.ddEV', '.dd-ev-card', function () {
+        var id = $(this).attr('data-ev-id');
+        if (id) openDetailModal(id);
+      });
+  }
+
+  /* ───────────────────────────────────────────
+     Data Loading
+     ─────────────────────────────────────────── */
+
+  function loadVehicles() {
+    var c = cfg();
+    var $grid = $('#dd-ev-grid');
+    var $loading = $('.dd-ev-loading');
+    var $empty = $('.dd-ev-empty-state');
+    var $pagination = $('#dd-ev-pagination');
+
+    $grid.hide();
+    $empty.hide();
+    $pagination.hide();
+    $loading.show();
+
+    var url = c.API_URL + '/api/v1/ems-vehicles' +
+      '?active_community_id=' + encodeURIComponent(c.communityId) +
+      '&user_id=' + encodeURIComponent(c.userId) +
+      '&limit=' + PAGE_SIZE +
+      '&page=' + ddPage;
+
+    if (ddSearchTerm) {
+      url += '&search=' + encodeURIComponent(ddSearchTerm);
+    }
+
+    $.ajax({
+      url: url,
+      method: 'GET',
+      success: function (data) {
+        $loading.hide();
+        ddData = parseList(data);
+        ddTotal = (data && data.totalCount != null) ? data.totalCount :
+                  (data && data.pagination && data.pagination.totalCount != null) ? data.pagination.totalCount :
+                  (ddData.length < PAGE_SIZE ? (ddPage * PAGE_SIZE + ddData.length) : -1);
+        renderGrid();
+      },
+      error: function () {
+        $loading.hide();
+        ddData = [];
+        renderGrid();
+        toast('Failed to load vehicles', 'error');
+      }
+    });
+  }
+
+  /* ───────────────────────────────────────────
+     Grid Rendering
+     ─────────────────────────────────────────── */
+
+  function renderGrid() {
+    var $grid = $('#dd-ev-grid');
+    var $empty = $('.dd-ev-empty-state');
+    $grid.empty();
+
+    if (!ddData.length) {
+      $grid.hide();
+      $empty.find('.dd-empty-title').text(ddSearchTerm ? 'No results found' : 'No vehicles yet');
+      $empty.find('.dd-empty-sub').text(ddSearchTerm ? 'Try a different search term' : 'Create your first vehicle to get started');
+      $empty.show();
+      updatePagination();
+      return;
+    }
+
+    $empty.hide();
+    $grid.show();
+
+    ddData.forEach(function (v) {
+      var model = esc(v.model || 'Unknown');
+      var meta = [];
+      if (v.engineNumber) meta.push('Eng: ' + esc(v.engineNumber));
+      if (v.color) meta.push(esc(v.color));
+
+      var icon = 'fa-ambulance';
+      if (model.toLowerCase().indexOf('fire') >= 0) icon = 'fa-fire-extinguisher';
+      else if (model.toLowerCase().indexOf('lifeguard') >= 0) icon = 'fa-life-ring';
+
+      var html = '' +
+        '<div class="dd-ev-card" data-ev-id="' + esc(v._id) + '">' +
+          '<div class="dd-ev-icon"><i class="fa ' + icon + '"></i></div>' +
+          '<div class="dd-ev-info">' +
+            '<div class="dd-ev-name">' + model + '</div>' +
+            '<div class="dd-ev-meta">' + (meta.join(' &middot; ') || 'No details') + '</div>' +
+            (v.plate ? '<span class="dd-ev-plate">' + esc(v.plate) + '</span>' : '') +
+          '</div>' +
+        '</div>';
+
+      $grid.append(html);
+    });
+
+    updatePagination();
+  }
+
+  function updatePagination() {
+    var $pagination = $('#dd-ev-pagination');
+    var $info = $('#dd-ev-page-info');
+    var $prev = $('#dd-ev-prev');
+    var $next = $('#dd-ev-next');
+
+    if (ddTotal <= PAGE_SIZE && ddPage === 0) {
+      $pagination.hide();
+      return;
+    }
+
+    $pagination.show();
+    var totalPages = ddTotal > 0 ? Math.ceil(ddTotal / PAGE_SIZE) : ddPage + 2;
+    $info.text('Page ' + (ddPage + 1) + (ddTotal > 0 ? ' of ' + totalPages : ''));
+    $prev.prop('disabled', ddPage <= 0);
+    $next.prop('disabled', ddTotal > 0 ? (ddPage + 1) * PAGE_SIZE >= ddTotal : ddData.length < PAGE_SIZE);
+  }
+
+  /* ───────────────────────────────────────────
+     Detail Modal
+     ─────────────────────────────────────────── */
+
+  function ensureDetailModal() {
+    if (detailModalReady) return;
+    detailModalReady = true;
+
+    var html = '' +
+      '<div class="dd-civ-new-overlay" id="dd-ev-detail-overlay">' +
+        '<div class="dd-civ-new-panel" style="max-width:560px;">' +
+          '<div class="dd-civ-new-header">' +
+            '<span class="dd-civ-new-title" id="dd-ev-detail-title">Vehicle Details</span>' +
+            '<button class="dd-civ-close" id="dd-ev-detail-close"><i class="fa fa-times"></i></button>' +
+          '</div>' +
+          '<div class="dd-civ-new-body" id="dd-ev-detail-body">' +
+            '<div class="dd-spinner"></div>' +
+          '</div>' +
+          '<div class="dd-civ-new-footer" id="dd-ev-detail-footer"></div>' +
+        '</div>' +
+      '</div>';
+
+    $('body').append(html);
+
+    $(document).off('click.ddEVDetail', '#dd-ev-detail-close')
+      .on('click.ddEVDetail', '#dd-ev-detail-close', closeDetailModal);
+    $(document).off('click.ddEVDetail', '#dd-ev-detail-overlay')
+      .on('click.ddEVDetail', '#dd-ev-detail-overlay', function (e) {
+        if (e.target === this) closeDetailModal();
+      });
+  }
+
+  function openDetailModal(id) {
+    ensureDetailModal();
+    var $overlay = $('#dd-ev-detail-overlay');
+    var $body = $('#dd-ev-detail-body');
+    var $footer = $('#dd-ev-detail-footer');
+
+    $body.html('<div class="dd-spinner"></div>');
+    $footer.empty();
+    $overlay.addClass('dd-civ-visible');
+
+    var c = cfg();
+    $.ajax({
+      url: c.API_URL + '/api/v1/ems-vehicles/' + encodeURIComponent(id),
+      method: 'GET',
+      success: function (data) {
+        var v = data.vehicle || data || {};
+
+        var fields = [
+          { label: 'Plate Number', val: v.plate },
+          { label: 'Model', val: v.model },
+          { label: 'Engine Number', val: v.engineNumber },
+          { label: 'Color', val: v.color },
+          { label: 'Registered Owner', val: v.registeredOwner }
+        ];
+
+        var html = '<div class="dd-civ-form-grid">';
+        fields.forEach(function (f) {
+          html += '<div class="dd-civ-field"><label>' + esc(f.label) + '</label>' +
+            '<div style="padding:0.5rem 0;color:var(--dd-text);font-size:0.875rem;">' + esc(f.val || 'N/A') + '</div></div>';
+        });
+        html += '</div>';
+
+        $('#dd-ev-detail-title').text(v.model || 'Vehicle Details');
+        $body.html(html);
+        $footer.html(
+          '<button class="dd-civ-btn dd-civ-btn-primary dd-civ-btn-small" id="dd-ev-edit-btn" data-id="' + esc(id) + '"><i class="fa fa-edit"></i> Edit</button>' +
+          '<button class="dd-civ-btn dd-civ-btn-danger dd-civ-btn-small" id="dd-ev-delete-btn" data-id="' + esc(id) + '"><i class="fa fa-trash"></i> Delete</button>'
+        );
+      },
+      error: function () {
+        $body.html('<p style="color:var(--dd-red);">Failed to load details</p>');
+        toast('Failed to load vehicle details', 'error');
+      }
+    });
+  }
+
+  function closeDetailModal() {
+    $('#dd-ev-detail-overlay').removeClass('dd-civ-visible');
+  }
+
+  // Edit button in detail modal
+  $(document).on('click.ddEV', '#dd-ev-edit-btn', function () {
+    var id = $(this).attr('data-id');
+    closeDetailModal();
+    openEditModal(id);
+  });
+
+  // Delete button in detail modal
+  $(document).on('click.ddEV', '#dd-ev-delete-btn', function () {
+    var id = $(this).attr('data-id');
+    if (window.ddModal) {
+      window.ddModal({
+        title: 'Delete Vehicle',
+        message: 'Are you sure you want to delete this vehicle? This action cannot be undone.',
+        confirmLabel: 'Delete',
+        confirmClass: 'dd-civ-btn-danger',
+        onConfirm: function () { deleteVehicle(id); }
+      });
+    } else {
+      if (confirm('Delete this vehicle?')) deleteVehicle(id);
+    }
+  });
+
+  /* ───────────────────────────────────────────
+     New Vehicle Modal
+     ─────────────────────────────────────────── */
+
+  function ensureNewModal() {
+    if (newModalReady) return;
+    newModalReady = true;
+
+    var modelOptions = VEHICLE_MODELS.map(function (m) {
+      return '<option value="' + esc(m) + '">' + esc(m) + '</option>';
+    }).join('');
+
+    var html = '' +
+      '<div class="dd-civ-new-overlay" id="dd-ev-new-overlay">' +
+        '<div class="dd-civ-new-panel" style="max-width:560px;">' +
+          '<div class="dd-civ-new-header">' +
+            '<span class="dd-civ-new-title" id="dd-ev-new-title">New Vehicle</span>' +
+            '<button class="dd-civ-close" id="dd-ev-new-close"><i class="fa fa-times"></i></button>' +
+          '</div>' +
+          '<div class="dd-civ-new-body">' +
+            '<div class="dd-civ-form-grid">' +
+              '<div class="dd-civ-field"><label>Plate Number *</label><input type="text" id="dd-ev-new-plate" maxlength="8" placeholder="e.g. FD-1234"></div>' +
+              '<div class="dd-civ-field"><label>Model *</label><select id="dd-ev-new-model">' + modelOptions + '</select></div>' +
+              '<div class="dd-civ-field"><label>Engine Number *</label><input type="text" id="dd-ev-new-engine" maxlength="10" placeholder="e.g. ENG-001"></div>' +
+              '<div class="dd-civ-field"><label>Color</label><input type="text" id="dd-ev-new-color" maxlength="30" placeholder="e.g. Red"></div>' +
+              '<div class="dd-civ-field dd-civ-form-full"><label>Registered Owner</label><input type="text" id="dd-ev-new-owner" maxlength="100" placeholder="e.g. Fire Department"></div>' +
+            '</div>' +
+          '</div>' +
+          '<div class="dd-civ-new-footer">' +
+            '<button class="dd-civ-btn dd-civ-btn-secondary" id="dd-ev-new-cancel">Cancel</button>' +
+            '<button class="dd-civ-btn dd-civ-btn-primary" id="dd-ev-new-save"><i class="fa fa-plus"></i> Create</button>' +
+          '</div>' +
+        '</div>' +
+      '</div>';
+
+    $('body').append(html);
+
+    $(document).off('click.ddEVNew', '#dd-ev-new-close, #dd-ev-new-cancel')
+      .on('click.ddEVNew', '#dd-ev-new-close, #dd-ev-new-cancel', closeNewModal);
+    $(document).off('click.ddEVNew', '#dd-ev-new-overlay')
+      .on('click.ddEVNew', '#dd-ev-new-overlay', function (e) {
+        if (e.target === this) closeNewModal();
+      });
+    $(document).off('click.ddEVNew', '#dd-ev-new-save')
+      .on('click.ddEVNew', '#dd-ev-new-save', createVehicle);
+  }
+
+  function openNewModal() {
+    ensureNewModal();
+    $('#dd-ev-new-plate').val('');
+    $('#dd-ev-new-model').val('Ambulance');
+    $('#dd-ev-new-engine').val('');
+    $('#dd-ev-new-color').val('');
+    $('#dd-ev-new-owner').val('');
+    $('#dd-ev-new-title').text('New Vehicle');
+    var $btn = $('#dd-ev-new-save');
+    $btn.prop('disabled', false).html('<i class="fa fa-plus"></i> Create');
+    $btn.off('click.ddEVNew').on('click.ddEVNew', createVehicle);
+    $('#dd-ev-new-overlay').addClass('dd-civ-visible');
+  }
+
+  function closeNewModal() {
+    $('#dd-ev-new-overlay').removeClass('dd-civ-visible');
+  }
+
+  function createVehicle() {
+    var plate = $('#dd-ev-new-plate').val().trim();
+    var model = $('#dd-ev-new-model').val();
+    var engineNumber = $('#dd-ev-new-engine').val().trim();
+    var color = $('#dd-ev-new-color').val().trim();
+    var registeredOwner = $('#dd-ev-new-owner').val().trim();
+    var c = cfg();
+
+    if (!plate || !model || !engineNumber) {
+      toast('Please fill in all required fields', 'error');
+      return;
+    }
+
+    if (plate.length > 8) { toast('Plate number must be 8 characters or less', 'error'); return; }
+    if (engineNumber.length > 10) { toast('Engine number must be 10 characters or less', 'error'); return; }
+
+    var $btn = $('#dd-ev-new-save');
+    $btn.prop('disabled', true).html('<i class="fa fa-spinner fa-spin"></i> Creating...');
+
+    $.ajax({
+      url: c.API_URL + '/api/v1/ems-vehicles',
+      method: 'POST',
+      contentType: 'application/json',
+      data: JSON.stringify({
+        vehicle: {
+          plate: plate,
+          model: model,
+          engineNumber: engineNumber,
+          color: color || undefined,
+          registeredOwner: registeredOwner || 'N/A',
+          activeCommunityID: c.communityId,
+          userID: c.userId
+        }
+      }),
+      success: function () {
+        toast('Vehicle created successfully', 'success');
+        closeNewModal();
+        ddPage = 0;
+        loadVehicles();
+      },
+      error: function (xhr) {
+        var msg = 'Failed to create vehicle';
+        try { msg = JSON.parse(xhr.responseText).error || msg; } catch (e) {}
+        toast(msg, 'error');
+      },
+      complete: function () {
+        $btn.prop('disabled', false).html('<i class="fa fa-plus"></i> Create');
+      }
+    });
+  }
+
+  /* ───────────────────────────────────────────
+     Edit Modal
+     ─────────────────────────────────────────── */
+
+  function openEditModal(id) {
+    ensureNewModal();
+    var c = cfg();
+    var $overlay = $('#dd-ev-new-overlay');
+
+    $overlay.addClass('dd-civ-visible');
+    $('#dd-ev-new-save').prop('disabled', true).html('<i class="fa fa-spinner fa-spin"></i>');
+
+    $.ajax({
+      url: c.API_URL + '/api/v1/ems-vehicles/' + encodeURIComponent(id),
+      method: 'GET',
+      success: function (data) {
+        var v = data.vehicle || data || {};
+        $('#dd-ev-new-plate').val(v.plate || '');
+        $('#dd-ev-new-model').val(v.model || 'Ambulance');
+        $('#dd-ev-new-engine').val(v.engineNumber || '');
+        $('#dd-ev-new-color').val(v.color || '');
+        $('#dd-ev-new-owner').val(v.registeredOwner || '');
+        $('#dd-ev-new-title').text('Edit Vehicle');
+
+        var $btn = $('#dd-ev-new-save');
+        $btn.prop('disabled', false).html('<i class="fa fa-save"></i> Update');
+        $btn.off('click.ddEVNew').on('click.ddEVNew', function () { updateVehicle(id); });
+      },
+      error: function () {
+        toast('Failed to load vehicle for editing', 'error');
+        closeNewModal();
+      }
+    });
+  }
+
+  function updateVehicle(id) {
+    var plate = $('#dd-ev-new-plate').val().trim();
+    var model = $('#dd-ev-new-model').val();
+    var engineNumber = $('#dd-ev-new-engine').val().trim();
+    var color = $('#dd-ev-new-color').val().trim();
+    var c = cfg();
+
+    if (!plate || !model || !engineNumber) {
+      toast('Please fill in all required fields', 'error');
+      return;
+    }
+
+    if (plate.length > 8) { toast('Plate number must be 8 characters or less', 'error'); return; }
+    if (engineNumber.length > 10) { toast('Engine number must be 10 characters or less', 'error'); return; }
+
+    var $btn = $('#dd-ev-new-save');
+    $btn.prop('disabled', true).html('<i class="fa fa-spinner fa-spin"></i> Updating...');
+
+    $.ajax({
+      url: c.API_URL + '/api/v1/ems-vehicles/' + encodeURIComponent(id),
+      method: 'PUT',
+      contentType: 'application/json',
+      data: JSON.stringify({
+        vehicle: {
+          plate: plate,
+          model: model,
+          engineNumber: engineNumber,
+          color: color || undefined,
+          activeCommunityID: c.communityId,
+          userID: c.userId
+        }
+      }),
+      success: function () {
+        toast('Vehicle updated successfully', 'success');
+        closeNewModal();
+        $('#dd-ev-new-save').off('click.ddEVNew').on('click.ddEVNew', createVehicle);
+        loadVehicles();
+      },
+      error: function (xhr) {
+        var msg = 'Failed to update vehicle';
+        try { msg = JSON.parse(xhr.responseText).error || msg; } catch (e) {}
+        toast(msg, 'error');
+      },
+      complete: function () {
+        $btn.prop('disabled', false).html('<i class="fa fa-save"></i> Update');
+      }
+    });
+  }
+
+  /* ───────────────────────────────────────────
+     Delete
+     ─────────────────────────────────────────── */
+
+  function deleteVehicle(id) {
+    var c = cfg();
+    $.ajax({
+      url: c.API_URL + '/api/v1/ems-vehicles/' + encodeURIComponent(id),
+      method: 'DELETE',
+      success: function () {
+        toast('Vehicle deleted successfully', 'success');
+        closeDetailModal();
+        loadVehicles();
+      },
+      error: function () {
+        toast('Failed to delete vehicle', 'error');
+      }
+    });
+  }
+
+  /* ───────────────────────────────────────────
+     Exports
+     ─────────────────────────────────────────── */
+
+  window.ddEmsVehRender = ddEmsVehRender;
+  window.ddEmsVehInit = ddEmsVehInit;
+
+})();

--- a/public/js/dd-medical.js
+++ b/public/js/dd-medical.js
@@ -1,0 +1,771 @@
+/**
+ * Department Dashboard — Medical Database Component
+ *
+ * Registers window.ddMedicalRender and window.ddMedicalInit for the
+ * department dashboard component registry. Provides civilian search,
+ * medical report CRUD, medication CRUD, and deceased status management.
+ */
+(function () {
+  'use strict';
+
+  /* ───────────────────────────────────────────
+     Helpers & Config
+     ─────────────────────────────────────────── */
+
+  var cfg = function () { return window.ddConfig || {}; };
+  var esc = function (s) { return window.esc ? window.esc(s) : String(s || '').replace(/[&<>"']/g, function(c){return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c];}); };
+  var toast = function (m, t) { if (window.ddToast) window.ddToast(m, t); };
+
+  function fmtDate(d) {
+    if (!d) return 'N/A';
+    var dt = new Date(d);
+    if (isNaN(dt) || dt.getFullYear() <= 1970) return 'N/A';
+    return (dt.getMonth()+1) + '/' + dt.getDate() + '/' + dt.getFullYear();
+  }
+
+  function toDateInput(val) {
+    if (!val) return '';
+    if (typeof val === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(val)) return val;
+    var d = new Date(val);
+    if (!isNaN(d.getTime()) && d.getFullYear() > 1970) return d.toISOString().substring(0, 10);
+    return '';
+  }
+
+  /* State */
+  var selectedCivilian = null; // { _id, name, birthday, deceased }
+  var currentView = 'search'; // 'search' | 'detail' | 'newReport' | 'newMed'
+  var reportPage = 0;
+  var reportLimit = 10;
+  var recentSearches = [];
+  var RECENT_KEY = 'dd_med_recent';
+
+  function loadRecentSearches() {
+    try { recentSearches = JSON.parse(localStorage.getItem(RECENT_KEY) || '[]'); } catch (e) { recentSearches = []; }
+  }
+  function saveRecentSearch(term) {
+    if (!term) return;
+    recentSearches = recentSearches.filter(function (s) { return s.toLowerCase() !== term.toLowerCase(); });
+    recentSearches.unshift(term);
+    if (recentSearches.length > 5) recentSearches = recentSearches.slice(0, 5);
+    try { localStorage.setItem(RECENT_KEY, JSON.stringify(recentSearches)); } catch (e) {}
+  }
+
+  /* ───────────────────────────────────────────
+     Styles
+     ─────────────────────────────────────────── */
+
+  function injectStyles() {
+    if (document.getElementById('dd-med-styles')) return;
+
+    var css = '' +
+      /* Search bar */
+      '.dd-med-search-bar{display:flex;gap:0.5rem;margin-bottom:0.75rem;}' +
+      '.dd-med-search-input{flex:1;background:var(--dd-glass);border:1px solid var(--dd-glass-border);border-radius:var(--dd-radius-sm);padding:0.5rem 0.75rem;color:var(--dd-text);font-family:inherit;font-size:0.8125rem;outline:none;transition:border-color 0.2s;}' +
+      '.dd-med-search-input:focus{border-color:rgba(255,255,255,0.15);}' +
+      '.dd-med-search-input::placeholder{color:var(--dd-text-dim);}' +
+      '.dd-med-search-btn{padding:0.5rem 1rem;border-radius:var(--dd-radius-sm);border:1px solid rgba(239,68,68,0.25);background:rgba(239,68,68,0.1);color:#fca5a5;font-family:inherit;font-size:0.8125rem;font-weight:500;cursor:pointer;transition:all 0.2s;white-space:nowrap;display:inline-flex;align-items:center;gap:0.375rem;}' +
+      '.dd-med-search-btn:hover{background:rgba(239,68,68,0.18);}' +
+
+      /* Recent searches */
+      '.dd-med-recent{display:flex;gap:0.35rem;flex-wrap:wrap;margin-bottom:0.75rem;}' +
+      '.dd-med-recent-tag{background:var(--dd-glass);border:1px solid var(--dd-glass-border);border-radius:999px;padding:0.25rem 0.625rem;font-size:0.6875rem;color:var(--dd-text-muted);cursor:pointer;transition:all 0.2s;}' +
+      '.dd-med-recent-tag:hover{background:rgba(255,255,255,0.06);color:var(--dd-text);}' +
+
+      /* Civilian cards */
+      '.dd-med-civ-list{display:flex;flex-direction:column;gap:0.5rem;}' +
+      '.dd-med-civ-item{background:var(--dd-glass);border:1px solid var(--dd-glass-border);border-radius:var(--dd-radius);padding:0.875rem 1rem;cursor:pointer;transition:all 0.2s;}' +
+      '.dd-med-civ-item:hover{background:rgba(255,255,255,0.06);transform:translateY(-1px);}' +
+      '.dd-med-civ-name{font-size:0.875rem;font-weight:600;color:var(--dd-text);}' +
+      '.dd-med-civ-meta{font-size:0.75rem;color:var(--dd-text-muted);margin-top:0.15rem;}' +
+      '.dd-med-deceased-badge{display:inline-block;font-size:0.625rem;font-weight:600;padding:0.15rem 0.5rem;border-radius:999px;background:rgba(239,68,68,0.15);color:var(--dd-red);margin-left:0.5rem;}' +
+
+      /* Detail header */
+      '.dd-med-detail-header{display:flex;align-items:center;justify-content:space-between;gap:0.5rem;margin-bottom:1rem;flex-wrap:wrap;}' +
+      '.dd-med-back-btn{background:none;border:none;color:var(--dd-text-muted);font-size:0.8125rem;cursor:pointer;display:inline-flex;align-items:center;gap:0.35rem;padding:0.25rem 0;}' +
+      '.dd-med-back-btn:hover{color:var(--dd-text);}' +
+      '.dd-med-civ-banner{background:var(--dd-glass);border:1px solid var(--dd-glass-border);border-radius:var(--dd-radius);padding:0.75rem 1rem;margin-bottom:1rem;display:flex;align-items:center;justify-content:space-between;gap:0.5rem;flex-wrap:wrap;}' +
+      '.dd-med-civ-banner-name{font-size:0.9375rem;font-weight:700;color:var(--dd-text);}' +
+      '.dd-med-civ-banner-meta{font-size:0.75rem;color:var(--dd-text-muted);}' +
+
+      /* Tabs */
+      '.dd-med-tabs{display:flex;gap:0.25rem;margin-bottom:0.75rem;background:var(--dd-glass);border:1.5px solid var(--dd-glass-border);border-radius:8px;padding:0.2rem;}' +
+      '.dd-med-tab{background:transparent;color:var(--dd-text-muted);border:none;border-radius:6px;padding:0.4rem 0.75rem;font-size:0.75rem;font-weight:500;cursor:pointer;transition:all 0.2s;flex:1;text-align:center;}' +
+      '.dd-med-tab.active{background:var(--dd-red);color:#fff;}' +
+
+      /* Action buttons row */
+      '.dd-med-actions{display:flex;gap:0.5rem;margin-bottom:0.75rem;flex-wrap:wrap;}' +
+      '.dd-med-action-btn{padding:0.4rem 0.75rem;border-radius:var(--dd-radius-sm);border:1px solid rgba(239,68,68,0.25);background:rgba(239,68,68,0.1);color:#fca5a5;font-family:inherit;font-size:0.75rem;font-weight:500;cursor:pointer;transition:all 0.2s;white-space:nowrap;display:inline-flex;align-items:center;gap:0.3rem;}' +
+      '.dd-med-action-btn:hover{background:rgba(239,68,68,0.18);}' +
+      '.dd-med-action-btn-amber{border-color:rgba(245,158,11,0.25);background:rgba(245,158,11,0.1);color:#fcd34d;}' +
+      '.dd-med-action-btn-amber:hover{background:rgba(245,158,11,0.18);}' +
+
+      /* Report cards */
+      '.dd-med-report{background:var(--dd-glass);border:1px solid var(--dd-glass-border);border-radius:var(--dd-radius);padding:0.75rem 1rem;margin-bottom:0.5rem;cursor:pointer;transition:all 0.2s;}' +
+      '.dd-med-report:hover{background:rgba(255,255,255,0.06);}' +
+      '.dd-med-report-date{font-size:0.75rem;color:var(--dd-text-muted);}' +
+      '.dd-med-report-details{font-size:0.8125rem;color:var(--dd-text);margin-top:0.15rem;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;}' +
+      '.dd-med-hosp-badge{display:inline-block;font-size:0.625rem;font-weight:600;padding:0.15rem 0.5rem;border-radius:999px;margin-top:0.25rem;}' +
+      '.dd-med-hosp-yes{background:rgba(245,158,11,0.15);color:var(--dd-amber);}' +
+      '.dd-med-hosp-no{background:rgba(34,197,94,0.15);color:var(--dd-green);}' +
+
+      /* Medication cards */
+      '.dd-med-med-item{background:var(--dd-glass);border:1px solid var(--dd-glass-border);border-radius:var(--dd-radius);padding:0.75rem 1rem;margin-bottom:0.5rem;cursor:pointer;transition:all 0.2s;}' +
+      '.dd-med-med-item:hover{background:rgba(255,255,255,0.06);}' +
+      '.dd-med-med-name{font-size:0.8125rem;font-weight:600;color:var(--dd-text);}' +
+      '.dd-med-med-meta{font-size:0.75rem;color:var(--dd-text-muted);margin-top:0.1rem;}' +
+
+      /* Responsive */
+      '@media(max-width:600px){.dd-med-search-bar{flex-direction:column;}.dd-med-actions{flex-direction:column;}}' +
+    '';
+
+    var style = document.createElement('style');
+    style.id = 'dd-med-styles';
+    style.textContent = css;
+    document.head.appendChild(style);
+  }
+
+  /* ───────────────────────────────────────────
+     Render
+     ─────────────────────────────────────────── */
+
+  function ddMedicalRender() {
+    return '' +
+      '<div class="dd-card-header">' +
+        '<div class="dd-card-header-left">' +
+          '<div class="dd-card-icon" style="background:rgba(239,68,68,0.15);color:var(--dd-red);"><i class="fa fa-heartbeat"></i></div>' +
+          '<div><h3 class="dd-card-title">Medical Database</h3><p class="dd-card-subtitle">Search and manage medical records</p></div>' +
+        '</div>' +
+      '</div>' +
+      '<div class="dd-card-body" id="dd-med-body">' +
+        '<div class="dd-spinner"></div>' +
+      '</div>';
+  }
+
+  /* ───────────────────────────────────────────
+     Init
+     ─────────────────────────────────────────── */
+
+  function ddMedicalInit() {
+    injectStyles();
+    loadRecentSearches();
+    selectedCivilian = null;
+    currentView = 'search';
+    renderSearchView();
+  }
+
+  /* ───────────────────────────────────────────
+     Search View
+     ─────────────────────────────────────────── */
+
+  function renderSearchView() {
+    currentView = 'search';
+    var $body = $('#dd-med-body');
+
+    var recentHtml = '';
+    if (recentSearches.length) {
+      recentHtml = '<div class="dd-med-recent">';
+      recentSearches.forEach(function (s) {
+        recentHtml += '<span class="dd-med-recent-tag" data-search="' + esc(s) + '"><i class="fa fa-clock" style="opacity:0.4;"></i> ' + esc(s) + '</span>';
+      });
+      recentHtml += '</div>';
+    }
+
+    $body.html(
+      '<div class="dd-med-search-bar">' +
+        '<input type="text" class="dd-med-search-input" id="dd-med-search" placeholder="Search by civilian name..." autocomplete="off">' +
+        '<button class="dd-med-search-btn" id="dd-med-search-go"><i class="fa fa-search"></i> Search</button>' +
+      '</div>' +
+      recentHtml +
+      '<div id="dd-med-results"></div>'
+    );
+
+    // Wire events
+    $(document).off('click.ddMed', '#dd-med-search-go').on('click.ddMed', '#dd-med-search-go', doSearch);
+    $(document).off('keydown.ddMed', '#dd-med-search').on('keydown.ddMed', '#dd-med-search', function (e) { if (e.key === 'Enter') doSearch(); });
+    $(document).off('click.ddMed', '.dd-med-recent-tag').on('click.ddMed', '.dd-med-recent-tag', function () {
+      var term = $(this).attr('data-search');
+      $('#dd-med-search').val(term);
+      doSearch();
+    });
+    $(document).off('click.ddMed', '.dd-med-civ-item').on('click.ddMed', '.dd-med-civ-item', function () {
+      var id = $(this).attr('data-civ-id');
+      var name = $(this).attr('data-civ-name');
+      var birthday = $(this).attr('data-civ-birthday');
+      var deceased = $(this).attr('data-civ-deceased') === 'true';
+      selectCivilian(id, name, birthday, deceased);
+    });
+  }
+
+  function doSearch() {
+    var term = ($('#dd-med-search').val() || '').trim();
+    if (!term) { toast('Please enter a name to search', 'error'); return; }
+
+    saveRecentSearch(term);
+    var c = cfg();
+    var $results = $('#dd-med-results');
+    $results.html('<div class="dd-spinner"></div>');
+
+    $.ajax({
+      url: c.API_URL + '/api/v1/civilians/search' +
+        '?name=' + encodeURIComponent(term) +
+        '&active_community_id=' + encodeURIComponent(c.communityId) +
+        '&limit=10&page=0',
+      method: 'GET',
+      success: function (data) {
+        var civs = data.civilians || data.data || data || [];
+        if (!Array.isArray(civs)) civs = [];
+
+        if (!civs.length) {
+          $results.html('<div class="dd-empty" style="padding:1.5rem;"><i class="fa fa-user-slash" style="font-size:1.5rem;opacity:0.3;margin-bottom:0.5rem;display:block;"></i><p style="color:var(--dd-text-muted);">No civilians found matching "' + esc(term) + '"</p></div>');
+          return;
+        }
+
+        var html = '<div class="dd-med-civ-list">';
+        civs.forEach(function (item) {
+          var civ = item.civilian || item || {};
+          var civId = item._id || civ._id || '';
+          var name = (civ.firstName || '') + ' ' + (civ.lastName || '');
+          if (!name.trim()) name = civ.name || 'Unknown';
+          var deceased = civ.deceased || false;
+
+          var metaParts = [];
+          if (civ.birthday) metaParts.push('DOB: ' + esc(civ.birthday));
+          if (civ.gender) metaParts.push(esc(civ.gender));
+          if (civ.race) metaParts.push(esc(civ.race));
+
+          html += '<div class="dd-med-civ-item" data-civ-id="' + esc(civId) + '" data-civ-name="' + esc(name.trim()) + '" data-civ-birthday="' + esc(civ.birthday || '') + '" data-civ-deceased="' + deceased + '">' +
+            '<div class="dd-med-civ-name">' + esc(name.trim()) +
+              (deceased ? '<span class="dd-med-deceased-badge"><i class="fa fa-skull-crossbones"></i> Deceased</span>' : '') +
+            '</div>' +
+            '<div class="dd-med-civ-meta">' + (metaParts.join(' &middot; ') || 'No details') + '</div>' +
+          '</div>';
+        });
+        html += '</div>';
+        $results.html(html);
+      },
+      error: function () {
+        $results.html('<div class="dd-empty" style="padding:1.5rem;"><p style="color:var(--dd-red);">Search failed. Please try again.</p></div>');
+      }
+    });
+  }
+
+  /* ───────────────────────────────────────────
+     Detail View (Reports + Medications)
+     ─────────────────────────────────────────── */
+
+  function selectCivilian(id, name, birthday, deceased) {
+    selectedCivilian = { _id: id, name: name, birthday: birthday, deceased: deceased };
+    renderDetailView('reports');
+  }
+
+  function renderDetailView(tab) {
+    currentView = 'detail';
+    var $body = $('#dd-med-body');
+    var civ = selectedCivilian;
+    if (!civ) { renderSearchView(); return; }
+
+    var deceasedBtn = civ.deceased
+      ? '<button class="dd-med-action-btn" id="dd-med-declare-alive"><i class="fa fa-heartbeat"></i> Declare Alive</button>'
+      : '<button class="dd-med-action-btn dd-med-action-btn-amber" id="dd-med-pronounce-dead"><i class="fa fa-skull-crossbones"></i> Pronounce Dead</button>';
+
+    $body.html(
+      '<div class="dd-med-detail-header">' +
+        '<button class="dd-med-back-btn" id="dd-med-back"><i class="fa fa-arrow-left"></i> Back to search</button>' +
+      '</div>' +
+      '<div class="dd-med-civ-banner">' +
+        '<div>' +
+          '<div class="dd-med-civ-banner-name">' + esc(civ.name) +
+            (civ.deceased ? '<span class="dd-med-deceased-badge"><i class="fa fa-skull-crossbones"></i> Deceased</span>' : '') +
+          '</div>' +
+          '<div class="dd-med-civ-banner-meta">DOB: ' + esc(civ.birthday || 'Unknown') + '</div>' +
+        '</div>' +
+        '<div>' + deceasedBtn + '</div>' +
+      '</div>' +
+      '<div class="dd-med-tabs" id="dd-med-tabs">' +
+        '<button class="dd-med-tab' + (tab === 'reports' ? ' active' : '') + '" data-med-tab="reports">Medical Reports</button>' +
+        '<button class="dd-med-tab' + (tab === 'medications' ? ' active' : '') + '" data-med-tab="medications">Medications</button>' +
+      '</div>' +
+      '<div class="dd-med-actions" id="dd-med-tab-actions"></div>' +
+      '<div id="dd-med-tab-content"><div class="dd-spinner"></div></div>'
+    );
+
+    // Wire events
+    $(document).off('click.ddMedDetail', '#dd-med-back').on('click.ddMedDetail', '#dd-med-back', function () { renderSearchView(); });
+    $(document).off('click.ddMedDetail', '.dd-med-tab').on('click.ddMedDetail', '.dd-med-tab', function () {
+      var t = $(this).attr('data-med-tab');
+      $('#dd-med-tabs .dd-med-tab').removeClass('active');
+      $(this).addClass('active');
+      if (t === 'reports') loadReports();
+      else loadMedications();
+    });
+    $(document).off('click.ddMedDetail', '#dd-med-pronounce-dead').on('click.ddMedDetail', '#dd-med-pronounce-dead', function () { toggleDeceased(true); });
+    $(document).off('click.ddMedDetail', '#dd-med-declare-alive').on('click.ddMedDetail', '#dd-med-declare-alive', function () { toggleDeceased(false); });
+
+    if (tab === 'reports') loadReports();
+    else loadMedications();
+  }
+
+  /* ── Reports ── */
+
+  function loadReports() {
+    var c = cfg();
+    var civ = selectedCivilian;
+    var $actions = $('#dd-med-tab-actions');
+    var $content = $('#dd-med-tab-content');
+
+    $actions.html('<button class="dd-med-action-btn" id="dd-med-new-report"><i class="fa fa-plus"></i> Create Report</button>');
+    $content.html('<div class="dd-spinner"></div>');
+
+    $(document).off('click.ddMedReport', '#dd-med-new-report').on('click.ddMedReport', '#dd-med-new-report', showNewReportForm);
+
+    $.ajax({
+      url: c.API_URL + '/api/v1/medical-reports' +
+        '?civilian_id=' + encodeURIComponent(civ._id) +
+        '&active_community_id=' + encodeURIComponent(c.communityId) +
+        '&limit=' + reportLimit + '&page=' + reportPage,
+      method: 'GET',
+      success: function (data) {
+        var reports = data.medicalReports || data.data || [];
+
+        if (!reports.length) {
+          $content.html('<div class="dd-empty" style="padding:1.5rem;"><div class="dd-empty-icon-wrap" style="background:rgba(239,68,68,0.08);border-color:rgba(239,68,68,0.15);"><i class="fa fa-file-medical" style="color:var(--dd-red);"></i></div><p class="dd-empty-title">No medical reports</p><p class="dd-empty-sub">Create a report to get started</p></div>');
+          return;
+        }
+
+        var html = '';
+        reports.forEach(function (r) {
+          var date = fmtDate(r.reportDate || r.date);
+          var hosp = r.hospitalized === 'yes' || r.hospitalized === true;
+          html += '<div class="dd-med-report" data-report-id="' + esc(r._id) + '">' +
+            '<div style="display:flex;justify-content:space-between;align-items:center;">' +
+              '<span class="dd-med-report-date">' + esc(date) + '</span>' +
+              '<span class="dd-med-hosp-badge ' + (hosp ? 'dd-med-hosp-yes' : 'dd-med-hosp-no') + '">' + (hosp ? 'Hospitalized' : 'Not Hospitalized') + '</span>' +
+            '</div>' +
+            '<div class="dd-med-report-details">' + esc(r.details || 'No details') + '</div>' +
+          '</div>';
+        });
+        $content.html(html);
+
+        // Wire report click
+        $(document).off('click.ddMedReport', '.dd-med-report').on('click.ddMedReport', '.dd-med-report', function () {
+          var id = $(this).attr('data-report-id');
+          if (id) openReportDetail(id);
+        });
+      },
+      error: function () {
+        $content.html('<p style="color:var(--dd-red);padding:1rem;">Failed to load medical reports</p>');
+      }
+    });
+  }
+
+  /* ── Report Detail ── */
+
+  function openReportDetail(reportId) {
+    var c = cfg();
+    var $content = $('#dd-med-tab-content');
+    var $actions = $('#dd-med-tab-actions');
+    $content.html('<div class="dd-spinner"></div>');
+    $actions.html('<button class="dd-med-back-btn" id="dd-med-report-back"><i class="fa fa-arrow-left"></i> Back to reports</button>');
+    $(document).off('click.ddMedRD', '#dd-med-report-back').on('click.ddMedRD', '#dd-med-report-back', loadReports);
+
+    $.ajax({
+      url: c.API_URL + '/api/v1/medical-reports/' + encodeURIComponent(reportId),
+      method: 'GET',
+      success: function (data) {
+        var r = data.report || data || {};
+        var hosp = r.hospitalized === 'yes' || r.hospitalized === true;
+
+        var html = '<div class="dd-civ-form-grid">' +
+          '<div class="dd-civ-field"><label>Date</label><div style="padding:0.5rem 0;color:var(--dd-text);font-size:0.875rem;">' + esc(fmtDate(r.reportDate || r.date)) + '</div></div>' +
+          '<div class="dd-civ-field"><label>Hospitalized</label><div style="padding:0.5rem 0;"><span class="dd-med-hosp-badge ' + (hosp ? 'dd-med-hosp-yes' : 'dd-med-hosp-no') + '">' + (hosp ? 'Yes' : 'No') + '</span></div></div>' +
+          '<div class="dd-civ-field dd-civ-form-full"><label>Details</label><div style="padding:0.5rem 0;color:var(--dd-text);font-size:0.875rem;line-height:1.6;">' + esc(r.details || 'N/A') + '</div></div>' +
+          '<div class="dd-civ-field"><label>Patient</label><div style="padding:0.5rem 0;color:var(--dd-text);font-size:0.875rem;">' + esc(r.name || 'N/A') + '</div></div>' +
+          '<div class="dd-civ-field"><label>Reporting EMS</label><div style="padding:0.5rem 0;color:var(--dd-text);font-size:0.875rem;">' + esc(r.reportingEmsID || 'N/A') + '</div></div>' +
+        '</div>' +
+        '<div style="display:flex;gap:0.5rem;margin-top:1rem;flex-wrap:wrap;">' +
+          '<button class="dd-civ-btn dd-civ-btn-primary dd-civ-btn-small" id="dd-med-edit-report" data-id="' + esc(reportId) + '"><i class="fa fa-edit"></i> Edit</button>' +
+          '<button class="dd-civ-btn dd-civ-btn-danger dd-civ-btn-small" id="dd-med-del-report" data-id="' + esc(reportId) + '"><i class="fa fa-trash"></i> Delete</button>' +
+        '</div>';
+
+        $content.html(html);
+
+        $(document).off('click.ddMedRD', '#dd-med-edit-report').on('click.ddMedRD', '#dd-med-edit-report', function () {
+          showEditReportForm($(this).attr('data-id'));
+        });
+        $(document).off('click.ddMedRD', '#dd-med-del-report').on('click.ddMedRD', '#dd-med-del-report', function () {
+          var id = $(this).attr('data-id');
+          if (window.ddModal) {
+            window.ddModal({ title: 'Delete Report', message: 'Delete this medical report?', confirmLabel: 'Delete', confirmClass: 'dd-civ-btn-danger', onConfirm: function () { deleteReport(id); } });
+          } else if (confirm('Delete this report?')) { deleteReport(id); }
+        });
+      },
+      error: function () { $content.html('<p style="color:var(--dd-red);">Failed to load report</p>'); }
+    });
+  }
+
+  /* ── New/Edit Report Form ── */
+
+  function showNewReportForm() {
+    var civ = selectedCivilian;
+    var c = cfg();
+    var $content = $('#dd-med-tab-content');
+    var $actions = $('#dd-med-tab-actions');
+    $actions.html('<button class="dd-med-back-btn" id="dd-med-report-back"><i class="fa fa-arrow-left"></i> Back to reports</button>');
+    $(document).off('click.ddMedRF', '#dd-med-report-back').on('click.ddMedRF', '#dd-med-report-back', loadReports);
+
+    $content.html(
+      '<div class="dd-civ-form-grid">' +
+        '<div class="dd-civ-field"><label>Date *</label><input type="date" id="dd-med-rf-date" value="' + toDateInput(new Date()) + '"></div>' +
+        '<div class="dd-civ-field"><label>Hospitalized</label><select id="dd-med-rf-hosp"><option value="no">No</option><option value="yes">Yes</option></select></div>' +
+        '<div class="dd-civ-field dd-civ-form-full"><label>Details *</label><textarea id="dd-med-rf-details" rows="4" placeholder="Describe the medical situation..." style="resize:vertical;"></textarea></div>' +
+      '</div>' +
+      '<div style="display:flex;gap:0.5rem;margin-top:1rem;">' +
+        '<button class="dd-civ-btn dd-civ-btn-secondary" id="dd-med-rf-cancel">Cancel</button>' +
+        '<button class="dd-civ-btn dd-civ-btn-primary" id="dd-med-rf-save"><i class="fa fa-plus"></i> Create Report</button>' +
+      '</div>'
+    );
+
+    $(document).off('click.ddMedRF', '#dd-med-rf-cancel').on('click.ddMedRF', '#dd-med-rf-cancel', loadReports);
+    $(document).off('click.ddMedRF', '#dd-med-rf-save').on('click.ddMedRF', '#dd-med-rf-save', function () { saveReport(null); });
+  }
+
+  function showEditReportForm(reportId) {
+    var c = cfg();
+    var $content = $('#dd-med-tab-content');
+    var $actions = $('#dd-med-tab-actions');
+    $content.html('<div class="dd-spinner"></div>');
+    $actions.html('<button class="dd-med-back-btn" id="dd-med-report-back"><i class="fa fa-arrow-left"></i> Back to reports</button>');
+    $(document).off('click.ddMedRF', '#dd-med-report-back').on('click.ddMedRF', '#dd-med-report-back', loadReports);
+
+    $.ajax({
+      url: c.API_URL + '/api/v1/medical-reports/' + encodeURIComponent(reportId),
+      method: 'GET',
+      success: function (data) {
+        var r = data.report || data || {};
+        $content.html(
+          '<div class="dd-civ-form-grid">' +
+            '<div class="dd-civ-field"><label>Date *</label><input type="date" id="dd-med-rf-date" value="' + toDateInput(r.reportDate || r.date) + '"></div>' +
+            '<div class="dd-civ-field"><label>Hospitalized</label><select id="dd-med-rf-hosp"><option value="no"' + (!(r.hospitalized === 'yes' || r.hospitalized === true) ? ' selected' : '') + '>No</option><option value="yes"' + ((r.hospitalized === 'yes' || r.hospitalized === true) ? ' selected' : '') + '>Yes</option></select></div>' +
+            '<div class="dd-civ-field dd-civ-form-full"><label>Details *</label><textarea id="dd-med-rf-details" rows="4" style="resize:vertical;">' + esc(r.details || '') + '</textarea></div>' +
+          '</div>' +
+          '<div style="display:flex;gap:0.5rem;margin-top:1rem;">' +
+            '<button class="dd-civ-btn dd-civ-btn-secondary" id="dd-med-rf-cancel">Cancel</button>' +
+            '<button class="dd-civ-btn dd-civ-btn-primary" id="dd-med-rf-save"><i class="fa fa-save"></i> Update Report</button>' +
+          '</div>'
+        );
+
+        $(document).off('click.ddMedRF', '#dd-med-rf-cancel').on('click.ddMedRF', '#dd-med-rf-cancel', loadReports);
+        $(document).off('click.ddMedRF', '#dd-med-rf-save').on('click.ddMedRF', '#dd-med-rf-save', function () { saveReport(reportId); });
+      },
+      error: function () { $content.html('<p style="color:var(--dd-red);">Failed to load report</p>'); }
+    });
+  }
+
+  function saveReport(reportId) {
+    var date = $('#dd-med-rf-date').val();
+    var details = $('#dd-med-rf-details').val().trim();
+    var hospitalized = $('#dd-med-rf-hosp').val() === 'yes';
+    var c = cfg();
+    var civ = selectedCivilian;
+
+    if (!date || !details) { toast('Please fill in all required fields', 'error'); return; }
+
+    var $btn = $('#dd-med-rf-save');
+    $btn.prop('disabled', true).html('<i class="fa fa-spinner fa-spin"></i> Saving...');
+
+    var payload = {
+      report: {
+        date: date,
+        details: details,
+        hospitalized: hospitalized,
+        civilianID: civ._id,
+        activeCommunityID: c.communityId,
+        userID: c.userId,
+        name: civ.name,
+        dateOfBirth: civ.birthday
+      }
+    };
+
+    var url = reportId
+      ? c.API_URL + '/api/v1/medical-reports/' + encodeURIComponent(reportId)
+      : c.API_URL + '/api/v1/medical-reports';
+    var method = reportId ? 'PUT' : 'POST';
+
+    $.ajax({
+      url: url,
+      method: method,
+      contentType: 'application/json',
+      data: JSON.stringify(payload),
+      success: function () {
+        toast('Medical report ' + (reportId ? 'updated' : 'created') + ' successfully', 'success');
+        loadReports();
+      },
+      error: function (xhr) {
+        var msg = 'Failed to save report';
+        try { msg = JSON.parse(xhr.responseText).message || msg; } catch (e) {}
+        toast(msg, 'error');
+        $btn.prop('disabled', false).html(reportId ? '<i class="fa fa-save"></i> Update Report' : '<i class="fa fa-plus"></i> Create Report');
+      }
+    });
+  }
+
+  function deleteReport(reportId) {
+    var c = cfg();
+    $.ajax({
+      url: c.API_URL + '/api/v1/medical-reports/' + encodeURIComponent(reportId),
+      method: 'DELETE',
+      success: function () { toast('Report deleted', 'success'); loadReports(); },
+      error: function () { toast('Failed to delete report', 'error'); }
+    });
+  }
+
+  /* ── Medications ── */
+
+  function loadMedications() {
+    var c = cfg();
+    var civ = selectedCivilian;
+    var $actions = $('#dd-med-tab-actions');
+    var $content = $('#dd-med-tab-content');
+
+    $actions.html('<button class="dd-med-action-btn" id="dd-med-new-med"><i class="fa fa-plus"></i> Add Medication</button>');
+    $content.html('<div class="dd-spinner"></div>');
+
+    $(document).off('click.ddMedMed', '#dd-med-new-med').on('click.ddMedMed', '#dd-med-new-med', showNewMedForm);
+
+    $.ajax({
+      url: c.API_URL + '/api/v1/medications' +
+        '?civilian_id=' + encodeURIComponent(civ._id) +
+        '&active_community_id=' + encodeURIComponent(c.communityId),
+      method: 'GET',
+      success: function (data) {
+        var meds = data.medications || data.data || [];
+        if (!Array.isArray(meds)) meds = [];
+
+        if (!meds.length) {
+          $content.html('<div class="dd-empty" style="padding:1.5rem;"><div class="dd-empty-icon-wrap" style="background:rgba(239,68,68,0.08);border-color:rgba(239,68,68,0.15);"><i class="fa fa-pills" style="color:var(--dd-red);"></i></div><p class="dd-empty-title">No medications</p><p class="dd-empty-sub">Add a medication to get started</p></div>');
+          return;
+        }
+
+        var html = '';
+        meds.forEach(function (m) {
+          var med = m.medication || m || {};
+          html += '<div class="dd-med-med-item" data-med-id="' + esc(m._id || med._id || '') + '">' +
+            '<div class="dd-med-med-name">' + esc(med.name || 'Unknown') + '</div>' +
+            '<div class="dd-med-med-meta">' + esc(med.dosage || '') + (med.frequency ? ' &middot; ' + esc(med.frequency) : '') + (med.startDate ? ' &middot; Since ' + fmtDate(med.startDate) : '') + '</div>' +
+          '</div>';
+        });
+        $content.html(html);
+
+        $(document).off('click.ddMedMed', '.dd-med-med-item').on('click.ddMedMed', '.dd-med-med-item', function () {
+          var id = $(this).attr('data-med-id');
+          if (id) openMedDetail(id);
+        });
+      },
+      error: function () {
+        $content.html('<p style="color:var(--dd-red);padding:1rem;">Failed to load medications</p>');
+      }
+    });
+  }
+
+  function openMedDetail(medId) {
+    var c = cfg();
+    var $content = $('#dd-med-tab-content');
+    var $actions = $('#dd-med-tab-actions');
+    $content.html('<div class="dd-spinner"></div>');
+    $actions.html('<button class="dd-med-back-btn" id="dd-med-med-back"><i class="fa fa-arrow-left"></i> Back to medications</button>');
+    $(document).off('click.ddMedMD', '#dd-med-med-back').on('click.ddMedMD', '#dd-med-med-back', loadMedications);
+
+    $.ajax({
+      url: c.API_URL + '/api/v1/medications/' + encodeURIComponent(medId),
+      method: 'GET',
+      success: function (data) {
+        var med = data.medication || data || {};
+        var html = '<div class="dd-civ-form-grid">' +
+          '<div class="dd-civ-field"><label>Medication Name</label><div style="padding:0.5rem 0;color:var(--dd-text);font-size:0.875rem;">' + esc(med.name || 'N/A') + '</div></div>' +
+          '<div class="dd-civ-field"><label>Dosage</label><div style="padding:0.5rem 0;color:var(--dd-text);font-size:0.875rem;">' + esc(med.dosage || 'N/A') + '</div></div>' +
+          '<div class="dd-civ-field"><label>Frequency</label><div style="padding:0.5rem 0;color:var(--dd-text);font-size:0.875rem;">' + esc(med.frequency || 'N/A') + '</div></div>' +
+          '<div class="dd-civ-field"><label>Start Date</label><div style="padding:0.5rem 0;color:var(--dd-text);font-size:0.875rem;">' + esc(fmtDate(med.startDate)) + '</div></div>' +
+        '</div>' +
+        '<div style="display:flex;gap:0.5rem;margin-top:1rem;flex-wrap:wrap;">' +
+          '<button class="dd-civ-btn dd-civ-btn-primary dd-civ-btn-small" id="dd-med-edit-med" data-id="' + esc(medId) + '"><i class="fa fa-edit"></i> Edit</button>' +
+          '<button class="dd-civ-btn dd-civ-btn-danger dd-civ-btn-small" id="dd-med-del-med" data-id="' + esc(medId) + '"><i class="fa fa-trash"></i> Delete</button>' +
+        '</div>';
+        $content.html(html);
+
+        $(document).off('click.ddMedMD', '#dd-med-edit-med').on('click.ddMedMD', '#dd-med-edit-med', function () {
+          showEditMedForm($(this).attr('data-id'));
+        });
+        $(document).off('click.ddMedMD', '#dd-med-del-med').on('click.ddMedMD', '#dd-med-del-med', function () {
+          var id = $(this).attr('data-id');
+          if (window.ddModal) {
+            window.ddModal({ title: 'Delete Medication', message: 'Delete this medication?', confirmLabel: 'Delete', confirmClass: 'dd-civ-btn-danger', onConfirm: function () { deleteMed(id); } });
+          } else if (confirm('Delete this medication?')) { deleteMed(id); }
+        });
+      },
+      error: function () { $content.html('<p style="color:var(--dd-red);">Failed to load medication</p>'); }
+    });
+  }
+
+  /* ── New/Edit Medication Form ── */
+
+  function showNewMedForm() {
+    var $content = $('#dd-med-tab-content');
+    var $actions = $('#dd-med-tab-actions');
+    $actions.html('<button class="dd-med-back-btn" id="dd-med-med-back"><i class="fa fa-arrow-left"></i> Back to medications</button>');
+    $(document).off('click.ddMedMF', '#dd-med-med-back').on('click.ddMedMF', '#dd-med-med-back', loadMedications);
+
+    $content.html(
+      '<div class="dd-civ-form-grid">' +
+        '<div class="dd-civ-field"><label>Medication Name *</label><input type="text" id="dd-med-mf-name" maxlength="100" placeholder="e.g. Ibuprofen"></div>' +
+        '<div class="dd-civ-field"><label>Dosage *</label><input type="text" id="dd-med-mf-dosage" maxlength="50" placeholder="e.g. 200mg"></div>' +
+        '<div class="dd-civ-field"><label>Frequency *</label><input type="text" id="dd-med-mf-freq" maxlength="50" placeholder="e.g. Twice daily"></div>' +
+        '<div class="dd-civ-field"><label>Start Date</label><input type="date" id="dd-med-mf-start" value="' + toDateInput(new Date()) + '"></div>' +
+      '</div>' +
+      '<div style="display:flex;gap:0.5rem;margin-top:1rem;">' +
+        '<button class="dd-civ-btn dd-civ-btn-secondary" id="dd-med-mf-cancel">Cancel</button>' +
+        '<button class="dd-civ-btn dd-civ-btn-primary" id="dd-med-mf-save"><i class="fa fa-plus"></i> Add Medication</button>' +
+      '</div>'
+    );
+
+    $(document).off('click.ddMedMF', '#dd-med-mf-cancel').on('click.ddMedMF', '#dd-med-mf-cancel', loadMedications);
+    $(document).off('click.ddMedMF', '#dd-med-mf-save').on('click.ddMedMF', '#dd-med-mf-save', function () { saveMed(null); });
+  }
+
+  function showEditMedForm(medId) {
+    var c = cfg();
+    var $content = $('#dd-med-tab-content');
+    $content.html('<div class="dd-spinner"></div>');
+
+    $.ajax({
+      url: c.API_URL + '/api/v1/medications/' + encodeURIComponent(medId),
+      method: 'GET',
+      success: function (data) {
+        var med = data.medication || data || {};
+        $content.html(
+          '<div class="dd-civ-form-grid">' +
+            '<div class="dd-civ-field"><label>Medication Name *</label><input type="text" id="dd-med-mf-name" maxlength="100" value="' + esc(med.name || '') + '"></div>' +
+            '<div class="dd-civ-field"><label>Dosage *</label><input type="text" id="dd-med-mf-dosage" maxlength="50" value="' + esc(med.dosage || '') + '"></div>' +
+            '<div class="dd-civ-field"><label>Frequency *</label><input type="text" id="dd-med-mf-freq" maxlength="50" value="' + esc(med.frequency || '') + '"></div>' +
+            '<div class="dd-civ-field"><label>Start Date</label><input type="date" id="dd-med-mf-start" value="' + toDateInput(med.startDate) + '"></div>' +
+          '</div>' +
+          '<div style="display:flex;gap:0.5rem;margin-top:1rem;">' +
+            '<button class="dd-civ-btn dd-civ-btn-secondary" id="dd-med-mf-cancel">Cancel</button>' +
+            '<button class="dd-civ-btn dd-civ-btn-primary" id="dd-med-mf-save"><i class="fa fa-save"></i> Update Medication</button>' +
+          '</div>'
+        );
+
+        $(document).off('click.ddMedMF', '#dd-med-mf-cancel').on('click.ddMedMF', '#dd-med-mf-cancel', loadMedications);
+        $(document).off('click.ddMedMF', '#dd-med-mf-save').on('click.ddMedMF', '#dd-med-mf-save', function () { saveMed(medId); });
+      },
+      error: function () { $content.html('<p style="color:var(--dd-red);">Failed to load medication</p>'); }
+    });
+  }
+
+  function saveMed(medId) {
+    var name = $('#dd-med-mf-name').val().trim();
+    var dosage = $('#dd-med-mf-dosage').val().trim();
+    var frequency = $('#dd-med-mf-freq').val().trim();
+    var startDate = $('#dd-med-mf-start').val();
+    var c = cfg();
+    var civ = selectedCivilian;
+
+    if (!name || !dosage || !frequency) { toast('Please fill in all required fields', 'error'); return; }
+
+    var $btn = $('#dd-med-mf-save');
+    $btn.prop('disabled', true).html('<i class="fa fa-spinner fa-spin"></i> Saving...');
+
+    var civName = (civ.name || '').split(' ');
+    var payload = {
+      medication: {
+        name: name,
+        dosage: dosage,
+        frequency: frequency,
+        startDate: startDate || undefined,
+        civilianID: civ._id,
+        activeCommunityID: c.communityId,
+        userID: c.userId,
+        firstName: civName[0] || '',
+        lastName: civName.slice(1).join(' ') || '',
+        dateOfBirth: civ.birthday
+      }
+    };
+
+    var url = medId
+      ? c.API_URL + '/api/v1/medications/' + encodeURIComponent(medId)
+      : c.API_URL + '/api/v1/medications';
+    var method = medId ? 'PUT' : 'POST';
+
+    $.ajax({
+      url: url,
+      method: method,
+      contentType: 'application/json',
+      data: JSON.stringify(payload),
+      success: function () {
+        toast('Medication ' + (medId ? 'updated' : 'added') + ' successfully', 'success');
+        loadMedications();
+      },
+      error: function (xhr) {
+        var msg = 'Failed to save medication';
+        try { msg = JSON.parse(xhr.responseText).message || msg; } catch (e) {}
+        toast(msg, 'error');
+        $btn.prop('disabled', false).html(medId ? '<i class="fa fa-save"></i> Update Medication' : '<i class="fa fa-plus"></i> Add Medication');
+      }
+    });
+  }
+
+  function deleteMed(medId) {
+    var c = cfg();
+    $.ajax({
+      url: c.API_URL + '/api/v1/medications/' + encodeURIComponent(medId),
+      method: 'DELETE',
+      success: function () { toast('Medication deleted', 'success'); loadMedications(); },
+      error: function () { toast('Failed to delete medication', 'error'); }
+    });
+  }
+
+  /* ── Deceased Toggle ── */
+
+  function toggleDeceased(setDeceased) {
+    var c = cfg();
+    var civ = selectedCivilian;
+
+    var confirmMsg = setDeceased
+      ? 'Pronounce ' + civ.name + ' as deceased?'
+      : 'Declare ' + civ.name + ' as alive?';
+
+    function doToggle() {
+      $.ajax({
+        url: c.API_URL + '/api/v1/civilians/' + encodeURIComponent(civ._id),
+        method: 'PUT',
+        contentType: 'application/json',
+        data: JSON.stringify({ civilian: { deceased: setDeceased } }),
+        success: function () {
+          selectedCivilian.deceased = setDeceased;
+          toast(setDeceased ? 'Pronounced deceased' : 'Declared alive', 'success');
+          renderDetailView($('#dd-med-tabs .dd-med-tab.active').attr('data-med-tab') || 'reports');
+        },
+        error: function () { toast('Failed to update status', 'error'); }
+      });
+    }
+
+    if (window.ddModal) {
+      window.ddModal({
+        title: setDeceased ? 'Pronounce Dead' : 'Declare Alive',
+        message: confirmMsg,
+        confirmLabel: setDeceased ? 'Pronounce Dead' : 'Declare Alive',
+        confirmClass: setDeceased ? 'dd-civ-btn-danger' : 'dd-civ-btn-primary',
+        onConfirm: doToggle
+      });
+    } else {
+      if (confirm(confirmMsg)) doToggle();
+    }
+  }
+
+  /* ───────────────────────────────────────────
+     Exports
+     ─────────────────────────────────────────── */
+
+  window.ddMedicalRender = ddMedicalRender;
+  window.ddMedicalInit = ddMedicalInit;
+
+})();

--- a/public/js/departments.js
+++ b/public/js/departments.js
@@ -136,12 +136,12 @@ function fetchAndRenderDepartments() {
           case "fire":
             icon = "fa-fire-extinguisher";
             action = "/select-department";
-            redirect = `/ems-dashboard${deptQueryParams}`;
+            redirect = `/department-dashboard${deptQueryParams}`;
             break;
           case "ems":
             icon = "fa-medkit";
             action = "/select-department";
-            redirect = `/ems-dashboard${deptQueryParams}`;
+            redirect = `/department-dashboard${deptQueryParams}`;
             break;
           case "judicial":
             icon = "fa-gavel";

--- a/public/js/modern-departments.js
+++ b/public/js/modern-departments.js
@@ -81,11 +81,11 @@ function fetchAndRenderModernDepartments() {
             break;
           case "fire":
             icon = "fa-fire-extinguisher";
-            action = `/ems-dashboard${deptQueryParams}`;
+            action = `/department-dashboard${deptQueryParams}`;
             break;
           case "ems":
             icon = "fa-medkit";
-            action = `/ems-dashboard${deptQueryParams}`;
+            action = `/department-dashboard${deptQueryParams}`;
             break;
           case "judicial":
             icon = "fa-gavel";

--- a/views/communities-owned.ejs
+++ b/views/communities-owned.ejs
@@ -45,7 +45,7 @@
                         <a href="/police-dashboard">Police</a>
                     </li>
                     <li>
-                        <a href="/ems-dashboard">Fire/EMS</a>
+                        <a href="/department-dashboard">Fire/EMS</a>
                     </li>
                     <li>
                         <a href="/dispatch-dashboard">Dispatch</a>

--- a/views/community-dashboard.ejs
+++ b/views/community-dashboard.ejs
@@ -300,7 +300,7 @@ $(document).ready(function () {
                     } else if (deptName.includes('police')) {
                         dashboardUrl = `/police-dashboard${deptQueryParams}`;
                     } else if (deptName.includes('fire') || deptName.includes('ems')) {
-                        dashboardUrl = `/ems-dashboard${deptQueryParams}`;
+                        dashboardUrl = `/department-dashboard${deptQueryParams}`;
                     } else if (deptName.includes('dispatch')) {
                         dashboardUrl = `/dispatch-dashboard${deptQueryParams}`;
                     } else if (deptName.includes('judicial')) {

--- a/views/community-details.ejs
+++ b/views/community-details.ejs
@@ -69,7 +69,7 @@
         } else if (templateType.includes('police')) {
           dashboardUrl = `/police-dashboard?dept=${encodeURIComponent(departmentName)}&d=${encodeDepartmentId(departmentId)}&c=${encodedCommunityId}`;
         } else if (templateType.includes('fire') || templateType.includes('ems')) {
-          dashboardUrl = `/ems-dashboard?dept=${encodeURIComponent(departmentName)}&d=${encodeDepartmentId(departmentId)}&c=${encodedCommunityId}`;
+          dashboardUrl = `/department-dashboard?dept=${encodeURIComponent(departmentName)}&d=${encodeDepartmentId(departmentId)}&c=${encodedCommunityId}`;
         } else if (templateType.includes('dispatch')) {
           dashboardUrl = `/dispatch-dashboard?dept=${encodeURIComponent(departmentName)}&d=${encodeDepartmentId(departmentId)}&c=${encodedCommunityId}`;
         } else if (templateType.includes('judicial')) {

--- a/views/department-dashboard.ejs
+++ b/views/department-dashboard.ejs
@@ -3341,6 +3341,52 @@
         render: renderCourtCasesPanel,
         init: loadCourtCases
       },
+      // ── EMS/Fire template components ──
+      personSearch: {
+        label: 'Personnel',
+        icon: 'fa-id-badge',
+        navIcon: 'fa-id-badge',
+        gridClass: 'dd-grid-full',
+        accentColor: 'var(--dd-blue)',
+        render: function(key) { return window.ddEmsPersonaRender ? window.ddEmsPersonaRender(key) : '<div class="dd-empty"><i class="fa fa-id-badge"></i><p>Loading personnel...</p></div>'; },
+        init: function() { if (window.ddEmsPersonaInit) window.ddEmsPersonaInit(); }
+      },
+      vehicleSearch: {
+        label: 'Vehicles',
+        icon: 'fa-ambulance',
+        navIcon: 'fa-ambulance',
+        gridClass: 'dd-grid-full',
+        accentColor: 'var(--dd-green)',
+        render: function(key) { return window.ddEmsVehRender ? window.ddEmsVehRender(key) : '<div class="dd-empty"><i class="fa fa-ambulance"></i><p>Loading vehicles...</p></div>'; },
+        init: function() { if (window.ddEmsVehInit) window.ddEmsVehInit(); }
+      },
+      medicalDatabase: {
+        label: 'Medical Database',
+        icon: 'fa-heartbeat',
+        navIcon: 'fa-heartbeat',
+        gridClass: 'dd-grid-full',
+        accentColor: 'var(--dd-red)',
+        render: function(key) { return window.ddMedicalRender ? window.ddMedicalRender(key) : '<div class="dd-empty"><i class="fa fa-heartbeat"></i><p>Loading medical database...</p></div>'; },
+        init: function() { if (window.ddMedicalInit) window.ddMedicalInit(); }
+      },
+      createBolos: {
+        label: 'BOLOs',
+        icon: 'fa-bullhorn',
+        navIcon: 'fa-bullhorn',
+        gridClass: 'dd-grid-full',
+        accentColor: 'var(--dd-amber)',
+        render: function(key) { return window.ddBoloCreateRender ? window.ddBoloCreateRender(key) : '<div class="dd-empty"><i class="fa fa-bullhorn"></i><p>Loading BOLOs...</p></div>'; },
+        init: function() { if (window.ddBoloCreateInit) window.ddBoloCreateInit(); }
+      },
+      viewBolosAndWarrants: {
+        label: 'BOLOs & Warrants',
+        icon: 'fa-eye',
+        navIcon: 'fa-eye',
+        gridClass: 'dd-grid-full',
+        accentColor: 'var(--dd-amber)',
+        render: function(key) { return window.ddBoloViewRender ? window.ddBoloViewRender(key) : '<div class="dd-empty"><i class="fa fa-eye"></i><p>Loading BOLOs & warrants...</p></div>'; },
+        init: function() { if (window.ddBoloViewInit) window.ddBoloViewInit(); }
+      },
       // ── Civilian template components ──
       createCivilians: {
         label: 'Civilians',
@@ -3435,8 +3481,8 @@
     var deptTypeConfig = {
       police:   { icon: 'fa-shield',          color: '#3b82f6', route: 'police' },
       dispatch: { icon: 'fa-headset',         color: '#8b5cf6', route: 'dispatch' },
-      fire:     { icon: 'fa-fire-extinguisher', color: '#f97316', route: 'ems' },
-      ems:      { icon: 'fa-medkit',           color: '#22c55e', route: 'ems' },
+      fire:     { icon: 'fa-fire-extinguisher', color: '#f97316', route: 'department' },
+      ems:      { icon: 'fa-medkit',           color: '#22c55e', route: 'department' },
       civilian: { icon: 'fa-user',             color: '#6b7280', route: 'department' },
       judicial: { icon: 'fa-gavel',            color: '#f59e0b', route: 'department' }
     };
@@ -6854,15 +6900,15 @@ $('#dd-loading').hide();
             href = '/department-dashboard' + params;
           } else if (template === 'judicial') {
             href = '/department-dashboard' + params;
-          } else if (['police', 'dispatch', 'fire', 'ems'].indexOf(template) !== -1) {
+          } else if (['police', 'dispatch'].indexOf(template) !== -1) {
             useFormPost = true;
             if (template === 'police') {
               redirect = '/police-dashboard' + params;
-            } else if (template === 'dispatch') {
-              redirect = '/dispatch-dashboard' + params;
             } else {
-              redirect = '/ems-dashboard' + params;
+              redirect = '/dispatch-dashboard' + params;
             }
+          } else if (template === 'fire' || template === 'ems') {
+            href = '/department-dashboard' + params;
           }
         }
 
@@ -7132,6 +7178,11 @@ $('#dd-loading').hide();
   <script src="/static/js/dd-civilians.js"></script>
   <script src="/static/js/dd-vehicles.js"></script>
   <script src="/static/js/dd-firearms.js"></script>
+  <!-- EMS/Fire template component scripts -->
+  <script src="/static/js/dd-ems-personas.js"></script>
+  <script src="/static/js/dd-ems-vehicles.js"></script>
+  <script src="/static/js/dd-medical.js"></script>
+  <script src="/static/js/dd-bolos.js"></script>
   <!-- Utility scripts -->
   <script src="/static/js/dd-911.js"></script>
   <script src="/static/js/dd-notifications.js"></script>

--- a/views/departments.ejs
+++ b/views/departments.ejs
@@ -446,7 +446,7 @@
     function getDashboardUrl(templateName) {
       if (templateName.includes('civilian')) return '/civ-dashboard';
       if (templateName.includes('police')) return '/police-dashboard';
-      if (templateName.includes('ems') || templateName.includes('fire')) return '/ems-dashboard';
+      if (templateName.includes('ems') || templateName.includes('fire')) return '/department-dashboard';
       if (templateName.includes('dispatch')) return '/dispatch-dashboard';
       return '';
     }

--- a/views/map-interactive.ejs
+++ b/views/map-interactive.ejs
@@ -41,7 +41,7 @@
                         <a href="/police-dashboard">Police</a>
                     </li>
                     <li>
-                        <a href="/ems-dashboard">Fire/EMS</a>
+                        <a href="/department-dashboard">Fire/EMS</a>
                     </li>
                     <li>
                         <a href="/dispatch-dashboard">Dispatch</a>

--- a/views/map-popular.ejs
+++ b/views/map-popular.ejs
@@ -41,7 +41,7 @@
                         <a href="/police-dashboard">Police</a>
                     </li>
                     <li>
-                        <a href="/ems-dashboard">Fire/EMS</a>
+                        <a href="/department-dashboard">Fire/EMS</a>
                     </li>
                     <li>
                         <a href="/dispatch-dashboard">Dispatch</a>


### PR DESCRIPTION
## Summary
- Converts the monolithic EMS dashboard into modular components using the department-dashboard registry pattern
- Adds 4 new component files: `dd-ems-personas.js` (personnel CRUD), `dd-ems-vehicles.js` (vehicle CRUD), `dd-medical.js` (medical database with reports/medications), `dd-bolos.js` (BOLOs + warrants view)
- Updates all routing across 9 files so fire/ems departments load `/department-dashboard` instead of `/ems-dashboard`
- Old `ems-dashboard` route and files are kept intact for rollback

## Test plan
- [ ] Navigate to a fire or EMS department from the community details page — should load department-dashboard
- [ ] Verify sidebar navigation from other dashboards routes to department-dashboard for fire/ems
- [ ] Test Personnel component: create, edit, delete EMS personas
- [ ] Test Vehicles component: create, edit, delete EMS vehicles
- [ ] Test Medical Database: search civilians, create/edit/delete medical reports and medications, toggle deceased status
- [ ] Test BOLOs: create, edit, delete BOLOs; view BOLOs & warrants in read-only tab
- [ ] Verify shared components still work: 10-codes, notepad, penal codes, court cases, 911 calls
- [ ] Verify old `/ems-dashboard` route still works for rollback

🤖 Generated with [Claude Code](https://claude.com/claude-code)