### PR TITLE
fix: modal submit buttons hidden on mobile phones

### DIFF
--- a/views/civ-dashboard.ejs
+++ b/views/civ-dashboard.ejs
@@ -5,7 +5,7 @@
   <title>LPC - Civilian Dashboard</title>
   <meta charset="utf-8">
   <meta name="description" content="Lines Roleplay Police CAD. Built to facilitate the needs of roleplay police and civilians." />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 
   <!-- Favicon -->
   <link rel="shortcut icon" type="image/ico" href="static/images/favicon.ico">
@@ -2118,9 +2118,13 @@
         margin: 0 !important;
         width: 100% !important;
         border-radius: 12px !important;
-        padding: 1.5rem 1rem 1rem 1rem !important;
+        padding: 1.5rem 1rem calc(2rem + env(safe-area-inset-bottom, 0px)) 1rem !important;
       }
-      
+
+      .modal .modal-body {
+        padding-bottom: calc(2rem + env(safe-area-inset-bottom, 0px)) !important;
+      }
+
       /* Ensure form elements are properly sized on mobile */
       .firearm-input {
         font-size: 16px !important; /* Prevents zoom on iOS */


### PR DESCRIPTION
## Summary
- Adds `viewport-fit=cover` to the viewport meta tag (required for `env(safe-area-inset-bottom)` to work)
- Adds safe-area bottom padding to all `.heroui-modal-content` and Bootstrap `.modal .modal-body` containers in the mobile media query
- Fixes submit/action buttons being hidden behind Android/iOS bottom navigation bars on the civilian dashboard modals (vehicle, firearm, license, 911 call, civilian creation, etc.)

## Test plan
- [ ] Open the civilian dashboard on an Android phone (or Chrome DevTools mobile emulation)
- [ ] Open the "Add New Vehicle" modal and verify the Create/Cancel buttons are visible
- [ ] Open the "Add New Civilian" modal and verify the Create/Cancel buttons are visible
- [ ] Open the "Add New License" modal and verify the Create/Cancel buttons are visible
- [ ] Open the "Call 911" modal and verify the Submit/Cancel buttons are visible
- [ ] Verify desktop layout is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)