### PR TITLE
fix: show approved warrants in command dashboard civilian search

### DIFF
--- a/public/js/cd-person-search.js
+++ b/public/js/cd-person-search.js
@@ -1064,12 +1064,12 @@
         })
         .done(function (data) {
           var warrants = Array.isArray(data) ? data : (data.warrants || data.data || []);
-          // Only keep active warrants
+          // Only keep active warrants (approved by judicial) and pending ones
           var active = [];
           for (var k = 0; k < warrants.length; k++) {
             var w = warrants[k].warrant || warrants[k];
             var status = (w.status || '').toLowerCase();
-            if (status === 'active' || status === 'pending' || status === '') {
+            if (status === 'approved' || status === 'pending') {
               active.push(warrants[k]);
             }
           }


### PR DESCRIPTION
## Summary
- The command dashboard person search was silently dropping warrants approved by the judicial department. When a user submitted a warrant and judicial accepted it, the warrant status became `approved`, but the person-search warrant filter only kept `active`, `pending`, or empty statuses — so the approved warrant never appeared on the civilian.
- Matches the filter already used correctly in `details-modal.js` (keep `approved` or `pending`).

## Changes
- `public/js/cd-person-search.js`: change warrant filter from `active|pending|''` to `approved|pending`.

## Test plan
- [ ] Submit a warrant for a civilian from the command dashboard
- [ ] Approve the warrant in the judicial department
- [ ] Return to command dashboard, search for the civilian, confirm the approved warrant now shows
- [ ] Submit a new warrant (status pending) and confirm it still shows
- [ ] Confirm denied/executed/expired/withdrawn warrants are still excluded