### PR TITLE
fix(admin-console): surface stuck user-lookup instead of infinite spinner

### DIFF
--- a/views/admin-console.ejs
+++ b/views/admin-console.ejs
@@ -7435,6 +7435,7 @@
         url: API_BASE + '/api/v1/admin/search/users',
         method: 'POST',
         contentType: 'application/json',
+        timeout: 15000,
         data: JSON.stringify({ query: email, page: 0, limit: 1 }),
         success: function(data) {
           var users = data.users || [];
@@ -7452,8 +7453,11 @@
           $('#caseNewOwnerPreview').html(previewHtml).show();
           $('#caseStep1Btn').prop('disabled', false).html('<i class="fas fa-exchange-alt"></i> Transfer Ownership').off('click').on('click', caseConfirmTransfer);
         },
-        error: function() {
-          $('#caseNewOwnerError').text('Failed to search for user.').show();
+        error: function(xhr, status) {
+          var msg = status === 'timeout'
+            ? 'Lookup timed out. The user may have a very large account record. Please try again.'
+            : 'Failed to search for user.';
+          $('#caseNewOwnerError').text(msg).show();
           $('#caseStep1Btn').prop('disabled', false).html('<i class="fas fa-search"></i> Look Up User');
         }
       });
@@ -7679,6 +7683,7 @@
         url: API_BASE + '/api/v1/admin/search/users',
         method: 'POST',
         contentType: 'application/json',
+        timeout: 15000,
         data: JSON.stringify({ query: email, page: 0, limit: 1 }),
         success: function(data) {
           var users = data.users || [];
@@ -7703,8 +7708,11 @@
           $('#caseBadActorPreview').html(previewHtml).show();
           $('#caseStep4Btn').prop('disabled', false).html('<i class="fas fa-user-slash"></i> Remove User').off('click').on('click', caseConfirmRemoval);
         },
-        error: function() {
-          $('#caseBadActorError').text('Failed to search for user.').show();
+        error: function(xhr, status) {
+          var msg = status === 'timeout'
+            ? 'Lookup timed out. The user may have a very large account record. Please try again.'
+            : 'Failed to search for user.';
+          $('#caseBadActorError').text(msg).show();
           $('#caseStep4Btn').prop('disabled', false).html('<i class="fas fa-search"></i> Look Up User');
         }
       });


### PR DESCRIPTION
## Summary
- The "Look Up User" buttons in the admin console case workflow (transfer ownership and remove bad actor) used jQuery \`\$.ajax\` with no \`timeout\`. When the backend search stalled — e.g. for accounts with very large user documents — the spinner would sit indefinitely with no way to recover.
- Adds a 15s client timeout to both \`caseLookupNewOwner\` and \`caseLookupBadActor\`, and surfaces a clear "lookup timed out" message so admins know to retry instead of waiting forever.
- Paired with API PR Linesmerrill/police-cad-api#118 which addresses the underlying cause (oversized doc decode + missing collation on \`user_email_idx\`). This PR is the defensive frontend half.

## Test plan
- [ ] On \`police-cad-dev\`, open \`/admin/console#cases/<id>\` → step 1, look up a known existing user → still works as before.
- [ ] Repeat at step 4 (remove bad actor) → still works.
- [ ] Simulate a stall by pointing API_BASE at a slow endpoint (or temporarily reverting the API fix) → confirm the spinner stops at 15s and shows the timeout message.