### PR TITLE
fix(economy-settings): clamp upper bound on numeric inputs

### DIFF
--- a/public/js/dd-settings.js
+++ b/public/js/dd-settings.js
@@ -683,13 +683,17 @@
     var enabled = $('#dds-economy-enabled').is(':checked');
     var basePayDollars = parseFloat($('#dds-economy-base-pay').val());
     if (!isFinite(basePayDollars) || basePayDollars < 0) basePayDollars = 0;
+    if (basePayDollars > 10000000) basePayDollars = 10000000; // $10M/hr dollar cap
     var basePayCents = Math.round(basePayDollars * 100);
     var maxSession = parseInt($('#dds-economy-max-session').val(), 10);
     if (!isFinite(maxSession) || maxSession < 1) maxSession = 120;
+    if (maxSession > 24 * 60 * 7) maxSession = 24 * 60 * 7;
     var afkPrompt = parseInt($('#dds-economy-afk-prompt').val(), 10);
     if (!isFinite(afkPrompt) || afkPrompt < 30) afkPrompt = 600;
+    if (afkPrompt > 86400) afkPrompt = 86400;
     var afkGrace = parseInt($('#dds-economy-afk-grace').val(), 10);
     if (!isFinite(afkGrace) || afkGrace < 10) afkGrace = 60;
+    if (afkGrace > 86400) afkGrace = 86400;
     var payoutMode = $('#dds-economy-payout-mode').val() === 'on_clockout' ? 'on_clockout' : 'on_heartbeat';
 
     showSaveStatus('#dds-economy-status', 'saving');

--- a/views/economy-settings.ejs
+++ b/views/economy-settings.ejs
@@ -461,12 +461,16 @@
     const enabled = get('economyEnabled').checked;
     let basePay = parseFloat(get('basePayPerHour').value);
     if (!isFinite(basePay) || basePay < 0) basePay = 0;
+    if (basePay > 10_000_000) basePay = 10_000_000; // $10M/hr dollar cap (server stores cents)
     let maxSess = parseInt(get('maxSessionMinutes').value, 10);
     if (!isFinite(maxSess) || maxSess < 1) maxSess = 120;
+    if (maxSess > 24 * 60 * 7) maxSess = 24 * 60 * 7;
     let afkPrompt = parseInt(get('afkPromptIntervalSeconds').value, 10);
     if (!isFinite(afkPrompt) || afkPrompt < 30) afkPrompt = 600;
+    if (afkPrompt > 86400) afkPrompt = 86400;
     let afkGrace = parseInt(get('afkGraceSeconds').value, 10);
     if (!isFinite(afkGrace) || afkGrace < 10) afkGrace = 60;
+    if (afkGrace > 86400) afkGrace = 86400;
     const payoutMode = get('payoutMode').value === 'on_clockout' ? 'on_clockout' : 'on_heartbeat';
 
     setRowStatus('saving', 'Saving…');


### PR DESCRIPTION
## Summary
- Adds upper-bound clamps on every numeric economy input on the website (department dashboard settings + the standalone economy settings page).
- Root cause was server-side (see [police-cad-api PR #119](https://github.com/Linesmerrill/police-cad-api/pull/119)) — the API blindly persisted any JSON value, and a giant number entered into the AFK prompt field landed in Mongo as a BSON Double, corrupting the community doc so every subsequent read 500'd with \`3e+22 overflows int64\`.
- The API now refuses such payloads; this PR adds the defense-in-depth client clamp so an honest typo never even leaves the browser.

## Test plan
- [ ] Open department dashboard → settings → economy. Try typing a 20+ digit number into the AFK prompt input → on save it gets capped at 86400.
- [ ] Same on the dedicated economy-settings page for each department.
- [ ] Negative values still floor to the documented minimum (already worked).
- [ ] Normal values (e.g. 300s) save unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)