### PR TITLE
Community boost patch

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -5016,7 +5016,7 @@ module.exports = function (app, passport, server, nextApp, handle) {
   app.get("/api/v1/communities/:userId", apiAuthCheck, async function (req, res) {
     try {
       const userId = req.params.userId;
-      if (!ObjectId.isValid(userId)) {
+      if (!_ObjectIdClass.isValid(userId)) {
         return res.status(400).json({ error: "Invalid user ID" });
       }
       const response = await axios.get(`${policeCadApiUrl}/api/v1/communities/${encodeURIComponent(userId)}`, {
@@ -5037,7 +5037,7 @@ module.exports = function (app, passport, server, nextApp, handle) {
   app.get("/api/v2/user/:userId/boost-communities", apiAuthCheck, async function (req, res) {
     try {
       const userId = req.params.userId;
-      if (!ObjectId.isValid(userId)) {
+      if (!_ObjectIdClass.isValid(userId)) {
         return res.status(400).json({ error: "Invalid user ID" });
       }
       const params = new URLSearchParams();

--- a/public/js/communities.js
+++ b/public/js/communities.js
@@ -1,6 +1,6 @@
 const { useState, useEffect, useRef, useCallback } = React;
 
-const API_URL = "https://police-cad-app-api-bc6d659b60b3.herokuapp.com";
+const API_URL = window.API_URL || "https://police-cad-app-api-bc6d659b60b3.herokuapp.com";
 
 // ============================================================================
 // UTILITY FUNCTIONS

--- a/views/communities.ejs
+++ b/views/communities.ejs
@@ -470,7 +470,7 @@
     <script>
       var dbUser = <%- JSON.stringify(user || {}) %>;
       // Global API_URL for notifications.js
-      window.API_URL = 'https://police-cad-app-api-bc6d659b60b3.herokuapp.com';
+      window.API_URL = '<%= process.env.POLICE_CAD_API_URL || "https://police-cad-app-api-bc6d659b60b3.herokuapp.com" %>';
 
       // Build version for footer
       window.buildVersion = '<%= typeof buildVersion !== "undefined" ? buildVersion : "unknown" %>';


### PR DESCRIPTION
## Summary

Unable to search communities on the `community-pricing` page when boosting. 

## Issues

The community proxy routes fail with `ObjectId.isValid is not a function` before forwarding requests to the API. This caused community lookup and boost community search requests to throw 500 from the frontend before the API could return proper results.

Also, the communities page was using a hardcoded production API URL in the browser script. This made local testing point at the production API unless the frontend was manually adjusted.

## Fixes
- Exposed configured `POLICE_CAD_API_URL` to the communities browser script.
- Falls back to the existing production API URL when no env var is configured.
- Updated the community proxy route validation to use the actual MongoDB `ObjectId` class for `isValid`.

## Testing

Tested locally with the frontend and API running against a test MongoDB database.

Verified that:
- the communities page uses the configured API URL locally
- `/api/v1/communities/:userId` no longer throws 500 before proxying
- `/api/v2/user/:userId/boost-communities` no longer throws 500 before proxying
- the community pricing page can search/select boost communities again