### PR TITLE
fix: pin @babel/standalone to v7 — Babel 8 automatic JSX runtime broke /communities and /profile

### DIFF
--- a/views/communities.ejs
+++ b/views/communities.ejs
@@ -448,56 +448,6 @@
       });
     </script>
     <div id="root"></div>
-    <!-- TEMP diagnostic (vanilla JS, no React/Babel dependency): reports why the
-         React communities app may not be mounting. Remove once resolved. -->
-    <script>
-    (function () {
-      var lines = [];
-      function render() {
-        var el = document.getElementById('__diag__');
-        if (!el) {
-          el = document.createElement('div');
-          el.id = '__diag__';
-          el.style.cssText = 'position:fixed;bottom:0;left:0;right:0;z-index:2147483647;background:#0b0b12;color:#7CFC00;font:12px/1.45 monospace;padding:8px 10px;max-height:45vh;overflow:auto;white-space:pre-wrap;border-top:2px solid #7CFC00;';
-          (document.body || document.documentElement).appendChild(el);
-        }
-        el.textContent = '[diag]\n' + lines.join('\n');
-      }
-      function add(m) { lines.push(m); try { console.warn('[diag]', m); } catch (e) {} }
-      window.addEventListener('error', function (e) {
-        add('JS ERROR: ' + (e && e.message ? e.message : e) + (e && e.filename ? ' @ ' + e.filename + ':' + (e.lineno || '') : ''));
-        scanScripts(); render();
-      });
-      window.addEventListener('unhandledrejection', function (e) {
-        add('PROMISE REJECT: ' + (e && e.reason ? (e.reason.message || e.reason) : e)); render();
-      });
-      function snapshot(tag) {
-        var root = document.getElementById('root');
-        add(tag + ' React=' + (typeof React) + ' ReactDOM=' + (typeof ReactDOM) + ' axios=' + (typeof axios) + ' Babel=' + (typeof Babel) + ' | #root children=' + (root ? root.childElementCount : 'NO #root'));
-      }
-      function scanScripts() {
-        var ss = document.getElementsByTagName('script');
-        for (var i = 0; i < ss.length; i++) {
-          var body = ss[i].textContent || '';
-          var m = body.match(/\bimport\s*[\{(]/);
-          if (m) {
-            var idx = body.indexOf(m[0]);
-            add('IMPORT FOUND in script#' + i + ' type=' + (ss[i].type || 'classic') + ' src=' + (ss[i].src || '(inline ' + body.length + 'ch)'));
-            add('  snippet: ' + body.slice(Math.max(0, idx - 30), idx + 90).replace(/\n/g, ' '));
-          }
-        }
-      }
-      window.addEventListener('load', function () {
-        snapshot('onload:');
-        setTimeout(function () {
-          snapshot('+4s:');
-          var root = document.getElementById('root');
-          // Only surface the on-page box if the app still failed to mount.
-          if (!root || root.childElementCount === 0) { scanScripts(); render(); }
-        }, 4000);
-      });
-    })();
-    </script>
     <script
       src="https://unpkg.com/react@18/umd/react.production.min.js"
       defer

--- a/views/communities.ejs
+++ b/views/communities.ejs
@@ -448,6 +448,35 @@
       });
     </script>
     <div id="root"></div>
+    <!-- TEMP diagnostic (vanilla JS, no React/Babel dependency): reports why the
+         React communities app may not be mounting. Remove once resolved. -->
+    <script>
+    (function () {
+      var lines = [];
+      function render() {
+        var el = document.getElementById('__diag__');
+        if (!el) {
+          el = document.createElement('div');
+          el.id = '__diag__';
+          el.style.cssText = 'position:fixed;bottom:0;left:0;right:0;z-index:2147483647;background:#0b0b12;color:#7CFC00;font:12px/1.45 monospace;padding:8px 10px;max-height:45vh;overflow:auto;white-space:pre-wrap;border-top:2px solid #7CFC00;';
+          (document.body || document.documentElement).appendChild(el);
+        }
+        el.textContent = '[diag]\n' + lines.join('\n');
+      }
+      function add(m) { lines.push(m); try { render(); } catch (e) {} }
+      window.addEventListener('error', function (e) {
+        add('JS ERROR: ' + (e && e.message ? e.message : e) + (e && e.filename ? ' @ ' + e.filename + ':' + (e.lineno || '') : ''));
+      });
+      window.addEventListener('unhandledrejection', function (e) {
+        add('PROMISE REJECT: ' + (e && e.reason ? (e.reason.message || e.reason) : e));
+      });
+      function snapshot(tag) {
+        var root = document.getElementById('root');
+        add(tag + ' React=' + (typeof React) + ' ReactDOM=' + (typeof ReactDOM) + ' axios=' + (typeof axios) + ' Babel=' + (typeof Babel) + ' | #root children=' + (root ? root.childElementCount : 'NO #root'));
+      }
+      window.addEventListener('load', function () { snapshot('onload:'); setTimeout(function () { snapshot('+4s:'); }, 4000); });
+    })();
+    </script>
     <script
       src="https://unpkg.com/react@18/umd/react.production.min.js"
       defer
@@ -483,7 +512,7 @@
     <script
       data-cfasync="false"
       type="text/babel"
-      src="/static/js/communities.js"
+      src="/static/js/communities.js?v=<%= typeof buildVersion !== 'undefined' ? buildVersion : 'dev' %>"
       defer
     ></script>
     <script

--- a/views/communities.ejs
+++ b/views/communities.ejs
@@ -463,12 +463,13 @@
         }
         el.textContent = '[diag]\n' + lines.join('\n');
       }
-      function add(m) { lines.push(m); try { render(); } catch (e) {} }
+      function add(m) { lines.push(m); try { console.warn('[diag]', m); } catch (e) {} }
       window.addEventListener('error', function (e) {
         add('JS ERROR: ' + (e && e.message ? e.message : e) + (e && e.filename ? ' @ ' + e.filename + ':' + (e.lineno || '') : ''));
+        scanScripts(); render();
       });
       window.addEventListener('unhandledrejection', function (e) {
-        add('PROMISE REJECT: ' + (e && e.reason ? (e.reason.message || e.reason) : e));
+        add('PROMISE REJECT: ' + (e && e.reason ? (e.reason.message || e.reason) : e)); render();
       });
       function snapshot(tag) {
         var root = document.getElementById('root');
@@ -488,8 +489,12 @@
       }
       window.addEventListener('load', function () {
         snapshot('onload:');
-        scanScripts();
-        setTimeout(function () { snapshot('+4s:'); scanScripts(); }, 4000);
+        setTimeout(function () {
+          snapshot('+4s:');
+          var root = document.getElementById('root');
+          // Only surface the on-page box if the app still failed to mount.
+          if (!root || root.childElementCount === 0) { scanScripts(); render(); }
+        }, 4000);
       });
     })();
     </script>
@@ -502,7 +507,7 @@
       defer
     ></script>
     <script
-      src="https://unpkg.com/@babel/standalone/babel.min.js"
+      src="https://unpkg.com/@babel/standalone@7/babel.min.js"
       defer
     ></script>
     <script src="https://unpkg.com/axios/dist/axios.min.js" defer></script>

--- a/views/communities.ejs
+++ b/views/communities.ejs
@@ -474,7 +474,23 @@
         var root = document.getElementById('root');
         add(tag + ' React=' + (typeof React) + ' ReactDOM=' + (typeof ReactDOM) + ' axios=' + (typeof axios) + ' Babel=' + (typeof Babel) + ' | #root children=' + (root ? root.childElementCount : 'NO #root'));
       }
-      window.addEventListener('load', function () { snapshot('onload:'); setTimeout(function () { snapshot('+4s:'); }, 4000); });
+      function scanScripts() {
+        var ss = document.getElementsByTagName('script');
+        for (var i = 0; i < ss.length; i++) {
+          var body = ss[i].textContent || '';
+          var m = body.match(/\bimport\s*[\{(]/);
+          if (m) {
+            var idx = body.indexOf(m[0]);
+            add('IMPORT FOUND in script#' + i + ' type=' + (ss[i].type || 'classic') + ' src=' + (ss[i].src || '(inline ' + body.length + 'ch)'));
+            add('  snippet: ' + body.slice(Math.max(0, idx - 30), idx + 90).replace(/\n/g, ' '));
+          }
+        }
+      }
+      window.addEventListener('load', function () {
+        snapshot('onload:');
+        scanScripts();
+        setTimeout(function () { snapshot('+4s:'); scanScripts(); }, 4000);
+      });
     })();
     </script>
     <script

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -12,7 +12,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://unpkg.com/@babel/standalone@7/babel.min.js"></script>
     <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
     <style>
       body {


### PR DESCRIPTION
## Root cause: Babel 8 broke the in-browser JSX pages site-wide

`/communities` (and `/profile`) load React + `@babel/standalone` from unpkg and transform the JSX page (`type="text/babel"`) in the browser. `@babel/standalone` was loaded **unpinned**, so it auto-updated to **Babel 8**, whose `@babel/preset-react` now defaults to the **automatic JSX runtime**. That makes the in-browser transform emit:

```js
import { jsx as _jsx } from "react/jsx-runtime";
```

at the top of the transformed script — which babel-standalone injects as a **classic** `<script>`. Safari/Chrome then throw:

```
SyntaxError: Unexpected token '{'. import call expects one or two arguments.
```

…the transformed `communities.js` never executes, so **React never mounts** (`#root` stays empty) and the page renders blank. This happened **with no code change on our side** — a Babel CDN release flipped the default. The native mobile app has no CORS/Babel, which is why it worked the entire time (and why CORS/data/section theories were all dead ends).

Confirmed with an on-page diagnostic:
```
JS ERROR: SyntaxError: ... import call expects one or two arguments @ /communities:24
onload: React=object ReactDOM=object axios=function Babel=object | #root children=0
```

## Fix
Pin `@babel/standalone` to **v7** (`@7`), whose `preset-react` defaults to the **classic** runtime (`React.createElement`, no `import`) — so the transformed script runs as a classic script again. Applied to both affected pages:
- `views/communities.ejs`
- `views/profile.ejs`

Also: cache-bust the `communities.js` include with `?v=<buildVersion>`, and leave a **non-intrusive** diagnostic (only appears if the app still fails to mount) for confirmation — I'll remove it in a follow-up once you confirm it's working.

## Verify after deploy
`/communities` and `/profile` load normally. (The green diagnostic box should NOT appear; if it does, it'll show the remaining error.)

## Follow-up
Any other page using `type="text/babel"` + unpinned `@babel/standalone` would have the same bug — I checked `views/` and only these two were unpinned, but worth grepping the whole app. Longer term, pin an exact version or precompile the JSX instead of transforming in-browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014aW3Ywj76tXX4nAQLiCTXu)_