### PR TITLE
feat(ranks): "reset stats on promotion" toggle + since-promotion labels

### DIFF
--- a/public/js/manage-ranks.js
+++ b/public/js/manage-ranks.js
@@ -20,6 +20,7 @@
   var _metricTypes = [];
   var _members = [];
   var _pendingPromotions = [];
+  var _resetStatsOnPromotion = false;
 
   var _membersPage = 1;
   var _membersTotalPages = 1;
@@ -78,10 +79,60 @@
     closePromotionsPanel();
 
     if (!_deptId) return;
+    loadRankSettings();
     loadMetricTypes();
     loadRanks();
     loadDeptMembers();
     loadPendingPromotions();
+  }
+
+  // ---------- Rank Settings (community-wide) ----------
+
+  // loadRankSettings reads the community-wide resetStatsOnPromotion flag so the panel
+  // toggle reflects the current value and progress labels read "since promotion".
+  function loadRankSettings() {
+    fetch(getApi() + '/api/v1/community/' + _communityId)
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        var community = (data && data.community) || data || {};
+        var rs = community.rankSettings || {};
+        _resetStatsOnPromotion = !!rs.resetStatsOnPromotion;
+        syncResetStatsToggle();
+      })
+      .catch(function () { /* leave default (all-time) */ });
+  }
+
+  function syncResetStatsToggle() {
+    var el = document.getElementById('rkmResetStatsToggle');
+    if (el) el.checked = _resetStatsOnPromotion;
+  }
+
+  // setResetStatsOnPromotion persists the community-wide flag. Updates optimistically
+  // so the toggle and progress labels reflect the change immediately.
+  function setResetStatsOnPromotion(enabled) {
+    var previous = _resetStatsOnPromotion;
+    _resetStatsOnPromotion = !!enabled;
+    syncResetStatsToggle();
+
+    fetch(getApi() + '/api/v1/community/' + _communityId + '?userId=' + encodeURIComponent(_userId), {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ 'rankSettings.resetStatsOnPromotion': _resetStatsOnPromotion })
+    })
+      .then(function (r) {
+        if (!r.ok) throw new Error('Failed to update setting');
+        if (typeof showToast === 'function') {
+          showToast(_resetStatsOnPromotion ? 'Stats now reset on promotion' : 'Stats now count all-time', 2500, 'success');
+        }
+        // Refresh progress so bars reflect since-promotion vs all-time.
+        loadPendingPromotions().then(renderPendingPromotions).catch(function () {});
+      })
+      .catch(function (err) {
+        console.error('Error updating rank settings:', err);
+        _resetStatsOnPromotion = previous;
+        syncResetStatsToggle();
+        if (typeof showToast === 'function') showToast('Failed to update setting', 3000, 'error');
+      });
   }
 
   function destroy() {
@@ -736,6 +787,10 @@
       var metricsHtml = '';
       if (p.progress && p.progress.length > 0) {
         metricsHtml = '<div class="rkm-promo-metrics">';
+        if (_resetStatsOnPromotion) {
+          metricsHtml += '<div class="rkm-promo-since-note" style="font-size:0.6rem; color:#94a3b8; text-transform:uppercase; letter-spacing:0.5px; margin-bottom:6px;">' +
+            '<i class="fa fa-rotate-left" style="margin-right:4px;"></i>Progress since last promotion</div>';
+        }
         p.progress.forEach(function (prog) {
           if (prog.isCustom) {
             var toggleId = 'customReqToggle_' + escapeRankHtml(p.userId) + '_' + escapeRankHtml(prog.requirementId || '');
@@ -752,11 +807,16 @@
               '</div>';
           } else {
             var pct = Math.min(Math.round((prog.percentage || 0) * 100), 100);
+            // In reset mode, show the lifetime total alongside the since-promotion count.
+            var allTimeSuffix = '';
+            if (_resetStatsOnPromotion && typeof prog.allTimeValue === 'number') {
+              allTimeSuffix = '<span class="rkm-promo-metric-alltime" style="color:#64748b; font-weight:400;"> · ' + prog.allTimeValue + ' all-time</span>';
+            }
             metricsHtml +=
               '<div class="rkm-promo-metric">' +
                 '<div class="rkm-promo-metric-header">' +
                   '<span class="rkm-promo-metric-name">' + escapeRankHtml(prog.displayName || prog.metricType) + '</span>' +
-                  '<span class="rkm-promo-metric-val">' + prog.currentValue + ' / ' + prog.threshold + ' <i class="fa fa-check" style="font-size:0.55rem;"></i></span>' +
+                  '<span class="rkm-promo-metric-val">' + prog.currentValue + ' / ' + prog.threshold + ' <i class="fa fa-check" style="font-size:0.55rem;"></i>' + allTimeSuffix + '</span>' +
                 '</div>' +
                 '<div class="rkm-promo-bar"><div class="rkm-promo-bar-fill" style="width:' + pct + '%"></div></div>' +
               '</div>';
@@ -1009,4 +1069,5 @@
   window.closePromotionsPanel = closePromotionsPanel;
   window.promoteOfficer = promoteOfficer;
   window.toggleCustomReq = toggleCustomReq;
+  window.setResetStatsOnPromotion = setResetStatsOnPromotion;
 })();

--- a/views/partials/community-details-modals.ejs
+++ b/views/partials/community-details-modals.ejs
@@ -832,6 +832,30 @@
         </div>
 
 
+        <!-- Rank Promotions Section -->
+        <div style="margin-bottom:2rem; padding:1.5rem; background:#2d3748; border-radius:12px; border:1px solid #4a5568;">
+          <div style="display:flex; align-items:center; gap:0.75rem; margin-bottom:1rem;">
+            <i class="fa fa-crown" style="font-size:1.5rem; color:#fbbf24;"></i>
+            <h4 style="color:#fff; margin:0; font-size:1.125rem; font-weight:600;">Rank Promotions</h4>
+          </div>
+          <p style="color:#a0aec0; margin-bottom:1rem; font-size:0.875rem;">Control how rank requirement progress is counted across all departments</p>
+
+          <div style="display:flex; align-items:center; gap:1rem; margin-bottom:1rem;">
+            <label style="display:flex; align-items:center; gap:0.5rem; color:#fff; font-weight:500; cursor:pointer;">
+              <input type="checkbox" id="enableResetStatsOnPromotion" style="width:1.25rem; height:1.25rem; accent-color:#3b82f6;">
+              Reset stats on promotion
+            </label>
+          </div>
+
+          <div id="resetStatsOnPromotionInfo" style="display:none; background:#1e3a8a; padding:1rem; border-radius:8px; margin:1rem 0; border-left:4px solid #3b82f6;">
+            <p style="margin:0; color:#93c5fd; font-size:0.875rem;">
+              <i class="fa fa-info-circle" style="color:#3b82f6; margin-right:0.5rem;"></i>
+              When enabled, requirement progress (arrests, citations, etc.) is counted since each member's last promotion instead of all-time, so every rank must be earned fresh. Lifetime totals are still shown alongside. When off, progress counts all-time.
+            </p>
+          </div>
+        </div>
+
+
         <!-- Warrant Approval Mode Section -->
         <div style="margin-bottom:2rem; padding:1.5rem; background:#2d3748; border-radius:12px; border:1px solid #4a5568;">
           <div style="display:flex; align-items:center; gap:0.75rem; margin-bottom:1rem;">
@@ -11225,13 +11249,21 @@ async function saveEditEvent() {
         
         // Set civilian approval system - use the actual field names from community JSON
         const enableApproval = communityData.community?.civilianApprovalSystemEnabled || false;
-        
+
         const enableApprovalElement = document.getElementById('enableCivilianApproval');
         if (enableApprovalElement) {
           enableApprovalElement.checked = enableApproval;
         }
-        
+
         toggleCivilianApprovalInfo(enableApproval);
+
+        // Set reset-stats-on-promotion (community-wide rank setting)
+        const enableResetStats = communityData.community?.rankSettings?.resetStatsOnPromotion || false;
+        const enableResetStatsElement = document.getElementById('enableResetStatsOnPromotion');
+        if (enableResetStatsElement) {
+          enableResetStatsElement.checked = enableResetStats;
+        }
+        toggleResetStatsOnPromotionInfo(enableResetStats);
 
         // Set vehicle creation limits - use the actual field names from community JSON
         const enableVehicleLimits = communityData.community?.vehicleCreationLimitsEnabled || false;
@@ -11338,13 +11370,21 @@ async function saveEditEvent() {
         
         // Set civilian approval system - use the actual field names from community JSON
         const enableApproval = communityData?.civilianApprovalSystemEnabled || false;
-        
+
         const enableApprovalElement = document.getElementById('enableCivilianApproval');
         if (enableApprovalElement) {
           enableApprovalElement.checked = enableApproval;
         }
-        
+
         toggleCivilianApprovalInfo(enableApproval);
+
+        // Set reset-stats-on-promotion (community-wide rank setting)
+        const enableResetStats = communityData?.rankSettings?.resetStatsOnPromotion || false;
+        const enableResetStatsElement = document.getElementById('enableResetStatsOnPromotion');
+        if (enableResetStatsElement) {
+          enableResetStatsElement.checked = enableResetStats;
+        }
+        toggleResetStatsOnPromotionInfo(enableResetStats);
 
         // Set vehicle creation limits - use the actual field names from community JSON
         const enableVehicleLimits = communityData?.vehicleCreationLimitsEnabled || false;
@@ -11414,7 +11454,15 @@ async function saveEditEvent() {
         enableApprovalCheckbox.addEventListener('change', function() {
           toggleCivilianApprovalInfo(this.checked);
         });
-        
+
+        // Reset-stats-on-promotion toggle
+        const enableResetStatsCheckbox = document.getElementById('enableResetStatsOnPromotion');
+        if (enableResetStatsCheckbox) {
+          enableResetStatsCheckbox.addEventListener('change', function() {
+            toggleResetStatsOnPromotionInfo(this.checked);
+          });
+        }
+
         // Vehicle limits toggle
         const enableVehicleLimitsCheckbox = document.getElementById('enableVehicleLimits');
         enableVehicleLimitsCheckbox.addEventListener('change', function() {
@@ -11464,10 +11512,18 @@ async function saveEditEvent() {
         }
       }
 
+      function toggleResetStatsOnPromotionInfo(show) {
+        const infoDiv = document.getElementById('resetStatsOnPromotionInfo');
+        if (!infoDiv) return;
+        infoDiv.style.display = show ? 'block' : 'none';
+      }
+
       function saveGeneralSettings() {
         const enableLimits = document.getElementById('enableCivilianLimits').checked;
         const maxCivilians = enableLimits ? parseInt(document.getElementById('maxCiviliansPerDept').value) : 5;
         const enableApproval = document.getElementById('enableCivilianApproval').checked;
+        const resetStatsEl = document.getElementById('enableResetStatsOnPromotion');
+        const enableResetStats = resetStatsEl ? resetStatsEl.checked : false;
 
         // Get vehicle limits
         const enableVehicleLimits = document.getElementById('enableVehicleLimits').checked;
@@ -11522,7 +11578,8 @@ async function saveEditEvent() {
           firearmCreationLimitsEnabled: enableFirearmLimits,
           firearmCreationLimit: maxFirearms,
           warrantApprovalMode: warrantApprovalMode,
-          warrantRandomApprovalRate: warrantRandomApprovalRate
+          warrantRandomApprovalRate: warrantRandomApprovalRate,
+          'rankSettings.resetStatsOnPromotion': enableResetStats
         };
 
         // Save to server - use the same route as saveCommunityProfile

--- a/views/partials/manage-ranks.ejs
+++ b/views/partials/manage-ranks.ejs
@@ -508,6 +508,13 @@
         <span class="rkm-panel-title"><i class="fa fa-crown" style="color:#fbbf24; margin-right:4px; font-size:0.6rem;"></i> Highest &rarr; Lowest</span>
         <button class="rkm-btn-add" id="addRankBtn" onclick="showRankForm()"><i class="fa fa-plus"></i> Add</button>
       </div>
+      <label class="rkm-reset-stats" style="display:flex; align-items:flex-start; gap:8px; padding:0.5rem 0.75rem; cursor:pointer; border-bottom:1px solid rgba(148,163,184,0.12);">
+        <input type="checkbox" id="rkmResetStatsToggle" onchange="window.setResetStatsOnPromotion(this.checked)" style="margin-top:2px; width:1rem; height:1rem; accent-color:#38bdf8; cursor:pointer; flex-shrink:0;">
+        <span style="display:flex; flex-direction:column; gap:1px;">
+          <span style="font-size:0.7rem; color:#e2e8f0; font-weight:600;">Reset stats on promotion</span>
+          <span style="font-size:0.6rem; color:#94a3b8; line-height:1.3;">Count requirement progress since each member's last promotion instead of all-time. Applies community-wide.</span>
+        </span>
+      </label>
       <div class="rkm-ranks-scroll" id="ranksList">
         <div class="rkm-empty"><i class="fa fa-spinner fa-spin"></i><p>Loading ranks...</p></div>
       </div>


### PR DESCRIPTION
## What

Website surface for the new community-wide **reset stats on promotion** setting (API: [police-cad-api#133](https://github.com/Linesmerrill/police-cad-api/pull/133)).

When enabled, rank requirement progress is counted since each member's last promotion instead of all-time. Default off = today's all-time behavior.

## Changes

- **Toggle in two places** (both bind to the same community-wide value):
  - General Settings modal → new "Rank Promotions" section.
  - Manage Ranks panel header.
  - Saved via `PATCH /api/v1/community/{id}` with `{"rankSettings.resetStatsOnPromotion": bool}` (nested `$set`, no API change needed).
- **Pending-promotions progress** shows "Progress since last promotion" and a `· N all-time` suffix on tracked metrics when the flag is on.
- Both toggles load their state from the community object so they stay in sync.

## Dependency

Requires police-cad-api#133 (adds the field + `resetStatsOnPromotion`/`allTimeValue` in responses) to be deployed first. Degrades safely otherwise (toggle off, all-time display).

## Test

- `node --check public/js/manage-ranks.js` passes.
- Manual: toggle on in either surface → persists, pending-promotions bars relabel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)