### PR TITLE
feat(arrest): live fine + jail-time totals on the arrest form

### DIFF
--- a/e2e/tests/operations/arrest-sentence-calc.spec.ts
+++ b/e2e/tests/operations/arrest-sentence-calc.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '../../fixtures/test-fixtures';
+import * as path from 'path';
+
+// Unit-tests the client sentence calculator that powers the arrest form's live
+// "Total Fine" / "Total Jail Time" and the consecutive/concurrent toggle. It
+// mirrors the authoritative Go implementation (models/arrest_sentence.go). We
+// load the script on about:blank (no CSP) and exercise the exposed helpers.
+test.describe('Arrest sentence calculator (cd-action-forms.js)', () => {
+  test('parses, totals (consecutive/concurrent), and formats jail time', async ({ unauthPage: page }) => {
+    await page.goto('about:blank');
+    await page.addScriptTag({ path: path.resolve(__dirname, '../../../public/js/cd-action-forms.js') });
+
+    const r = await page.evaluate(() => {
+      const w = window as unknown as {
+        cdParseJailTime: (s: string) => { seconds: number; isLife: boolean };
+        cdTotalJailTime: (c: Array<{ jailTime: string }>, mode: string) => { seconds: number; label: string };
+        cdFormatDuration: (s: number) => string;
+      };
+      const charges = [{ jailTime: '30 seconds' }, { jailTime: '2 minutes' }];
+      return {
+        sixMonths: w.cdParseJailTime('6 months').seconds,
+        naZero: w.cdParseJailTime('N/A').seconds,
+        life: w.cdParseJailTime('Life').isLife,
+        consecutive: w.cdTotalJailTime(charges, 'consecutive').label,
+        concurrent: w.cdTotalJailTime(charges, 'concurrent').label,
+        lifeOverride: w.cdTotalJailTime(charges.concat([{ jailTime: 'Life' }]), 'consecutive').label,
+        format: w.cdFormatDuration(2592045),
+        empty: w.cdFormatDuration(0),
+      };
+    });
+
+    expect(r.sixMonths).toBe(6 * 2592000);
+    expect(r.naZero).toBe(0);
+    expect(r.life).toBe(true);
+    expect(r.consecutive).toBe('2 minutes 30 seconds');
+    expect(r.concurrent).toBe('2 minutes');
+    expect(r.lifeOverride).toBe('Life');
+    expect(r.format).toBe('1 month 45 seconds');
+    expect(r.empty).toBe('None');
+  });
+});

--- a/public/js/cd-action-forms.js
+++ b/public/js/cd-action-forms.js
@@ -298,6 +298,25 @@
       '  font-size: 20px; font-weight: 700;',
       '  color: var(--cd-accent, #38bdf8);',
       '}',
+      /* Arrest sentence summary (total fine + total jail time + mode) */
+      '.cd-af-arr-totals {',
+      '  margin-top: 12px; padding: 8px 16px;',
+      '  background: rgba(56,189,248,0.06);',
+      '  border: 1px solid rgba(56,189,248,0.15);',
+      '  border-radius: var(--cd-radius-sm, 8px);',
+      '}',
+      '.cd-af-arr-total-row {',
+      '  display: flex; align-items: center; justify-content: space-between;',
+      '  padding: 6px 0;',
+      '}',
+      '.cd-af-arr-mode-row {',
+      '  display: flex; align-items: center; justify-content: space-between;',
+      '  margin-top: 6px; padding-top: 10px;',
+      '  border-top: 1px solid var(--cd-glass-border, rgba(255,255,255,0.06));',
+      '}',
+      '.cd-af-arr-mode-label {',
+      '  font-size: 13px; font-weight: 500; color: var(--cd-text-muted, #64748b);',
+      '}',
 
       /* Violations / Checkboxes */
       '.cd-af-violations-loading {',
@@ -600,7 +619,7 @@
    *
    * @param {string}   containerId  ID of the container element
    * @param {object}   [opts]       { showFines: true, onChange: fn }
-   * @returns {function} getSelected => [{ name, fine, category }]
+   * @returns {function} getSelected => [{ name, fine, jailTime, category }]
    */
   function renderViolations(containerId, opts) {
     opts = opts || {};
@@ -634,7 +653,7 @@
           var fineStr = (opts.showFines !== false && v.fine)
             ? formatCurrency(v.fine, currency)
             : '';
-          listHtml += '<div class="cd-af-cb-item" data-uid="' + uid + '" data-name="' + esc(v.name) + '" data-fine="' + (v.fine || 0) + '" data-cat="' + esc(cat.name) + '">';
+          listHtml += '<div class="cd-af-cb-item" data-uid="' + uid + '" data-name="' + esc(v.name) + '" data-fine="' + (v.fine || 0) + '" data-jail="' + esc(v.jailTime || '') + '" data-cat="' + esc(cat.name) + '">';
           listHtml += '  <div class="cd-af-cb-box"><i class="fa fa-check cd-af-cb-check"></i></div>';
           listHtml += '  <span class="cd-af-cb-label">' + esc(v.name) + '</span>';
           if (fineStr) listHtml += '  <span class="cd-af-cb-fine">' + esc(fineStr) + '</span>';
@@ -741,6 +760,7 @@
             selected[uid] = {
               name: this.getAttribute('data-name'),
               fine: parseFloat(this.getAttribute('data-fine')) || 0,
+              jailTime: this.getAttribute('data-jail') || '',
               category: this.getAttribute('data-cat')
             };
             this.classList.add('cd-af-cb-checked');
@@ -767,6 +787,65 @@
     } catch (e) {
       return '$' + Number(amount).toFixed(2);
     }
+  }
+
+  /* ──────────── Sentence calculator (mirrors API models/arrest_sentence.go) ──────────── */
+
+  var JAIL_UNIT_SECONDS = {
+    second: 1, seconds: 1, sec: 1, secs: 1,
+    minute: 60, minutes: 60, min: 60, mins: 60,
+    hour: 3600, hours: 3600, hr: 3600, hrs: 3600,
+    day: 86400, days: 86400,
+    week: 604800, weeks: 604800, wk: 604800, wks: 604800,
+    month: 2592000, months: 2592000, mo: 2592000, mos: 2592000,
+    year: 31536000, years: 31536000, yr: 31536000, yrs: 31536000
+  };
+  var JAIL_LIFE_RE = /\b(life|perp|perpetual|death|permanent)\b/i;
+  var JAIL_SEGMENT_RE = /(\d+(?:\.\d+)?)\s*([a-zA-Z]+)/g;
+
+  /* Parse a free-form jail-time string into { seconds, isLife }. */
+  function parseJailTime(raw) {
+    var s = (raw == null ? '' : String(raw)).toLowerCase().trim();
+    if (!s || s === 'n/a' || s === 'na' || s === 'none' || s === '0') return { seconds: 0, isLife: false };
+    if (JAIL_LIFE_RE.test(s)) return { seconds: 0, isLife: true };
+    var total = 0, m;
+    JAIL_SEGMENT_RE.lastIndex = 0;
+    while ((m = JAIL_SEGMENT_RE.exec(s)) !== null) {
+      var unit = JAIL_UNIT_SECONDS[m[2].toLowerCase()];
+      if (!unit) continue;
+      var val = parseFloat(m[1]);
+      if (!isNaN(val)) total += Math.round(val * unit);
+    }
+    return { seconds: total, isLife: false };
+  }
+
+  /* Render seconds as up to the two most-significant non-zero units. */
+  function formatDuration(seconds) {
+    if (!seconds || seconds <= 0) return 'None';
+    var units = [['year', 31536000], ['month', 2592000], ['day', 86400], ['hour', 3600], ['minute', 60], ['second', 1]];
+    var parts = [], remaining = seconds;
+    for (var i = 0; i < units.length && parts.length < 2; i++) {
+      var lbl = units[i][0], sz = units[i][1];
+      if (remaining < sz) continue;
+      var n = Math.floor(remaining / sz);
+      remaining = remaining % sz;
+      parts.push(n + ' ' + lbl + (n !== 1 ? 's' : ''));
+    }
+    return parts.join(' ');
+  }
+
+  /* Total jail time across charges. mode 'consecutive' (sum, default) | 'concurrent' (max). */
+  function totalJailTime(charges, mode) {
+    var sum = 0, longest = 0, anyLife = false;
+    for (var i = 0; i < charges.length; i++) {
+      var p = parseJailTime(charges[i].jailTime);
+      if (p.isLife) anyLife = true;
+      sum += p.seconds;
+      if (p.seconds > longest) longest = p.seconds;
+    }
+    if (anyLife) return { seconds: -1, isLife: true, label: 'Life' };
+    var secs = (mode === 'concurrent') ? longest : sum;
+    return { seconds: secs, isLife: false, label: formatDuration(secs) };
   }
 
   /* ───────────────────────── Character Counter ───────────────────────── */
@@ -974,6 +1053,24 @@
       '<div class="cd-af-section">Charges</div>' +
       '<div id="cd-af-arr-violations"></div>' +
 
+      '<div class="cd-af-arr-totals" id="cd-af-arr-totals">' +
+        '<div class="cd-af-arr-total-row">' +
+          '<span class="cd-af-total-fine-label">Total Fine</span>' +
+          '<span class="cd-af-total-fine-amount" id="cd-af-arr-total-fine">$0.00</span>' +
+        '</div>' +
+        '<div class="cd-af-arr-total-row">' +
+          '<span class="cd-af-total-fine-label">Total Jail Time</span>' +
+          '<span class="cd-af-total-fine-amount" id="cd-af-arr-total-time">None</span>' +
+        '</div>' +
+        '<div class="cd-af-arr-mode-row">' +
+          '<span class="cd-af-arr-mode-label">Sentences run</span>' +
+          '<div class="cd-af-toggle-wrap" id="cd-af-arr-mode-wrap">' +
+            '<button type="button" class="cd-af-toggle-btn" data-mode="consecutive">Consecutive</button>' +
+            '<button type="button" class="cd-af-toggle-btn" data-mode="concurrent">Concurrent</button>' +
+          '</div>' +
+        '</div>' +
+      '</div>' +
+
       '<div class="cd-af-section">Force Used?</div>' +
       '<div class="cd-af-field">' +
         '<div class="cd-af-toggle-wrap" id="cd-af-arr-force-wrap">' +
@@ -1001,8 +1098,37 @@
 
     openPanel('fa-gavel', 'Create Arrest Report', civName, body, footer);
 
-    /* Violations */
-    var getSelected = renderViolations('cd-af-arr-violations', { showFines: false });
+    /* Violations + live sentence totals */
+    var sentenceMode = 'consecutive';
+    function updateArrTotals(sel) {
+      sel = sel || getSelected();
+      var totalFine = 0;
+      for (var i = 0; i < sel.length; i++) totalFine += (sel[i].fine || 0);
+      var fineEl = document.getElementById('cd-af-arr-total-fine');
+      if (fineEl) fineEl.textContent = formatCurrency(totalFine, (penalCodesCache && penalCodesCache.currency) || 'USD');
+      var timeEl = document.getElementById('cd-af-arr-total-time');
+      if (timeEl) timeEl.textContent = totalJailTime(sel, sentenceMode).label;
+    }
+    var getSelected = renderViolations('cd-af-arr-violations', {
+      showFines: true,
+      onChange: updateArrTotals
+    });
+
+    /* Consecutive / concurrent toggle */
+    var modeWrap = document.getElementById('cd-af-arr-mode-wrap');
+    if (modeWrap) {
+      modeWrap.querySelector('[data-mode="consecutive"]').classList.add('cd-af-toggle-active');
+      var modeBtns = modeWrap.querySelectorAll('.cd-af-toggle-btn');
+      for (var mi = 0; mi < modeBtns.length; mi++) {
+        modeBtns[mi].addEventListener('click', function () {
+          sentenceMode = this.getAttribute('data-mode');
+          var btns = modeWrap.querySelectorAll('.cd-af-toggle-btn');
+          for (var mj = 0; mj < btns.length; mj++) btns[mj].classList.remove('cd-af-toggle-active');
+          this.classList.add('cd-af-toggle-active');
+          updateArrTotals();
+        });
+      }
+    }
 
     /* Character counters */
     bindCharCounter('cd-af-arr-narrative', 'cd-af-arr-narrative-count', 500);
@@ -1080,6 +1206,10 @@
             badgeNumber: dbUser.callSign || ''
           },
           charges: chargeNames.join(', '),
+          chargesList: sel.map(function (s) {
+            return { name: s.name, amount: s.fine || 0, category: s.category || '', jailTime: s.jailTime || '' };
+          }),
+          sentenceMode: sentenceMode,
           narrative: narrative,
           witnesses: witnesses,
           forceUsed: forceUsed,
@@ -1226,5 +1356,9 @@
   window.cdShowArrestForm = showArrestForm;
   window.cdShowWarrantForm = showWarrantForm;
   window.cdCloseActionForm = closePanel;
+  /* Sentence calculator — exposed for reuse + testing (mirrors API models/arrest_sentence.go) */
+  window.cdParseJailTime = parseJailTime;
+  window.cdFormatDuration = formatDuration;
+  window.cdTotalJailTime = totalJailTime;
 
 })();

--- a/public/js/cd-person-search.js
+++ b/public/js/cd-person-search.js
@@ -1342,6 +1342,17 @@
           sectionHead('Charges') +
           '<div style="font-size:0.875rem;color:#f1f5f9;font-weight:500;line-height:1.5;margin-bottom:0.75rem;">' + esc(ar.charges || 'None') + '</div>' +
 
+          // Sentence totals (stored on newer records; older ones omit them)
+          ((ar.totalFine > 0 || (ar.totalJailTimeLabel && ar.totalJailTimeLabel !== 'None')) ?
+            '<div style="display:flex;gap:1.5rem;flex-wrap:wrap;margin-bottom:0.75rem;">' +
+              (ar.totalFine > 0 ?
+                '<div><div style="font-size:0.625rem;text-transform:uppercase;letter-spacing:0.08em;color:#475569;font-weight:600;">Total Fine</div>' +
+                '<div style="font-size:0.875rem;font-weight:700;color:var(--cd-amber);">$' + Number(ar.totalFine).toFixed(2) + '</div></div>' : '') +
+              (ar.totalJailTimeLabel && ar.totalJailTimeLabel !== 'None' ?
+                '<div><div style="font-size:0.625rem;text-transform:uppercase;letter-spacing:0.08em;color:#475569;font-weight:600;">Total Jail Time</div>' +
+                '<div style="font-size:0.875rem;font-weight:700;color:var(--cd-accent,#38bdf8);">' + esc(ar.totalJailTimeLabel) + '</div></div>' : '') +
+            '</div>' : '') +
+
           // Narrative
           sectionHead('Narrative') +
           '<div style="font-size:0.8125rem;color:#cbd5e1;line-height:1.6;white-space:pre-wrap;background:rgba(0,0,0,0.2);border-radius:8px;padding:0.75rem;border:1px solid rgba(255,255,255,0.03);margin-bottom:0.75rem;">' + esc(ar.narrative || 'No narrative provided.') + '</div>' +


### PR DESCRIPTION
## What

Client half of **Arrest Fine & Time Calculation** on the command-dashboard arrest form.

- **cd-action-forms.js**: a sentence calculator (`parseJailTime` / `formatDuration` / `totalJailTime`) mirroring the API's Go implementation, exposed on `window` for reuse + testing. The charge picker now captures each charge's `jailTime`.
- **Arrest form**: live **Total Fine** + **Total Jail Time** plus a **Consecutive / Concurrent** toggle; submits `chargesList` (name, amount, category, jailTime) + `sentenceMode` so the API stores canonical totals.
- **cd-person-search.js**: the arrest detail view shows the stored Total Fine + Total Jail Time (omitted on older records that predate the fields).
- **e2e**: `operations/arrest-sentence-calc.spec.ts` unit-tests the calculator in-browser (`about:blank` + `addScriptTag`) — parse, consecutive/concurrent totals, Life override, formatting.

## Depends on

The API PR (chargesList persistence + server-side total recompute). Server is the source of truth on save; the client math here drives the live in-form preview.

## Base branch

Targets the **`feature/audio-alerts-and-whats-new`** soak branch (not `main`) to ride the current soak → deploy cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
