### PR TITLE
fix(alerts): warrant tone silent when results already cached

### DIFF
--- a/public/js/cd-person-search.js
+++ b/public/js/cd-person-search.js
@@ -1056,8 +1056,12 @@
     }
 
     if (ids.length === 0) {
+      // Every result's warrants are already cached this session — still evaluate
+      // the tone, otherwise re-searching a person who has an active warrant is
+      // silent (the tone check used to live only inside the fetch callback).
       state.loading = false;
       renderResults();
+      maybePlayWarrantTone();
       return;
     }
 
@@ -1091,25 +1095,27 @@
           if (pending <= 0) {
             state.loading = false;
             renderResults();
-            // Audible warrant alert (opt-in via CAD Alert Sounds): sound once
-            // if any person in the CURRENT results has an active warrant. Scope
-            // to state.results (not the whole warrantCache) — the cache
-            // accumulates every civilian searched this session, so scanning it
-            // would fire the tone on a later clean search and repeat it while
-            // paginating. state.results is replaced per page, so this reflects
-            // only what's on screen now.
-            var anyWarrants = false;
-            for (var r = 0; r < state.results.length; r++) {
-              var rid = state.results[r] && state.results[r]._id;
-              if (rid && state.warrantCache[rid] && state.warrantCache[rid].length > 0) {
-                anyWarrants = true;
-                break;
-              }
-            }
-            if (anyWarrants && window.AlertSounds) AlertSounds.playAlert('warrantAlert');
+            maybePlayWarrantTone();
           }
         });
       })(ids[j]);
+    }
+  }
+
+  // Audible warrant alert (opt-in via CAD Alert Sounds): sound once if any
+  // person in the CURRENT results has an active warrant. Called on every search
+  // completion — including when all results were already cached this session —
+  // so re-searching a wanted person still alerts. Scoped to state.results (not
+  // the whole warrantCache): the cache accumulates every civilian searched this
+  // session, so scanning it would fire the tone on a later clean search.
+  // state.results is replaced per page, so it reflects only what's on screen now.
+  function maybePlayWarrantTone() {
+    for (var r = 0; r < state.results.length; r++) {
+      var rid = state.results[r] && state.results[r]._id;
+      if (rid && state.warrantCache[rid] && state.warrantCache[rid].length > 0) {
+        if (window.AlertSounds) AlertSounds.playAlert('warrantAlert');
+        return;
+      }
     }
   }
 


### PR DESCRIPTION
During soak testing, searching a person with an active warrant played no tone even though the **WARRANTS** badge showed and `AlertSounds.preview('warrantAlert', 100)` worked.

**Root cause:** the tone call (`playAlert('warrantAlert')`) lived only inside the per-civilian warrant-fetch `.always` callback. When every result's warrants were already cached this session (re-searching a person, or having expanded them earlier), `fetchWarrantsForResults` hit the `ids.length === 0` early return and skipped the tone entirely. First-ever search of a person fired it; re-searching them was silent.

**Fix:** extracted the check into `maybePlayWarrantTone()` and call it on **both** completion paths — the fetch callback and the all-cached early return. Still scoped to `state.results` (not the whole session cache) so it only alerts on what's on screen.

Targets the soak branch so it rides the current soak → deploy.

Note: this is separate from the opt-in gate — the tone still requires **Account → CAD Alert Sounds** to be on (`preview` bypasses that gate, which is why it played from the console).

🤖 Generated with [Claude Code](https://claude.com/claude-code)