### PR TITLE
fix(ranks): honor reset-stats-on-promotion on the officer rank card

### DIFF
--- a/public/js/rank-progress.js
+++ b/public/js/rank-progress.js
@@ -42,6 +42,10 @@ function renderRankProgress(data, allRanks) {
   var nextRank = data.nextRank;
   var metrics = data.metrics || [];
   var progress = data.progress || [];
+  // When the community resets stats on promotion, currentValue counts from the
+  // member's last promotion rather than all-time — label it and show the
+  // lifetime figure for context (mirrors the admin Manage Ranks panel).
+  var resetStatsOnPromotion = !!data.resetStatsOnPromotion;
   allRanks = allRanks || [];
 
   if (!currentRank) return; // No rank system configured
@@ -105,10 +109,15 @@ function renderRankProgress(data, allRanks) {
         var barBg = pct >= 100 ? 'linear-gradient(90deg, #059669, #10b981)' : 'linear-gradient(90deg, #6d28d9, #8b5cf6)';
         var valColor = pct >= 100 ? '#34d399' : '#c4b5fd';
         var checkmark = pct >= 100 ? ' <i class="fa fa-check-circle" style="color:#34d399; font-size:13px; margin-left:4px;"></i>' : '';
+        // Lifetime total alongside the since-promotion count, when they differ.
+        var allTimeSuffix = '';
+        if (resetStatsOnPromotion && typeof p.allTimeValue === 'number' && p.allTimeValue !== p.currentValue) {
+          allTimeSuffix = ' <span style="color:#7c7f96; font-size:11px; font-weight:500;">· ' + p.allTimeValue + ' all-time</span>';
+        }
         barsHtml += '<div style="padding:0;">' +
           '<div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:6px;">' +
             '<span style="color:#c8c6d8; font-size:14px; font-weight:500;">' + escapeHtmlRank(p.displayName || p.metricType) + checkmark + '</span>' +
-            '<span style="color:' + valColor + '; font-size:14px; font-weight:700; font-variant-numeric:tabular-nums;">' + p.currentValue + ' / ' + p.threshold + '</span>' +
+            '<span style="color:' + valColor + '; font-size:14px; font-weight:700; font-variant-numeric:tabular-nums;">' + p.currentValue + ' / ' + p.threshold + allTimeSuffix + '</span>' +
           '</div>' +
           '<div style="width:100%; height:8px; background:rgba(55,65,81,0.6); border-radius:4px; overflow:hidden;">' +
             '<div style="width:' + pct + '%; height:100%; background:' + barBg + '; border-radius:4px; transition:width 0.6s cubic-bezier(0.4,0,0.2,1);"></div>' +
@@ -163,12 +172,37 @@ function renderRankProgress(data, allRanks) {
     if (statsSection) statsSection.style.display = 'block';
     var gridHtml = '';
     metrics.forEach(function(m) {
+      // Lifetime figure under the tile so "since promotion" numbers don't look
+      // like lost progress.
+      var allTimeLine = '';
+      if (resetStatsOnPromotion && typeof m.allTimeValue === 'number' && m.allTimeValue !== m.currentValue) {
+        allTimeLine = '<div style="color:#5b5e73; font-size:10px; font-weight:500; margin-top:4px; line-height:1.2;">' + m.allTimeValue + ' all-time</div>';
+      }
       gridHtml += '<div style="background:rgba(30,32,40,0.7); border:1px solid rgba(53,56,90,0.5); border-radius:10px; padding:14px 12px; text-align:center;">' +
         '<div style="color:#fff; font-size:24px; font-weight:700; line-height:1.1; font-variant-numeric:tabular-nums;">' + (m.currentValue || 0) + '</div>' +
         '<div style="color:#7c7f96; font-size:11px; text-transform:uppercase; letter-spacing:0.8px; font-weight:500; margin-top:6px; line-height:1.3;">' + escapeHtmlRank(m.displayName || m.metricType) + '</div>' +
+        allTimeLine +
       '</div>';
     });
     gridContainer.innerHTML = gridHtml;
+
+    // Caption the grid so officers know which window these numbers cover.
+    // Created on the fly — this script is shared by several dashboards and
+    // none of them declare the element.
+    var statsCaption = document.getElementById('rankStatsCaption');
+    if (!statsCaption && gridContainer && gridContainer.parentNode) {
+      statsCaption = document.createElement('div');
+      statsCaption.id = 'rankStatsCaption';
+      statsCaption.style.cssText =
+        'color:#7c7f96; font-size:11px; font-weight:500; letter-spacing:0.3px; margin-bottom:8px;';
+      gridContainer.parentNode.insertBefore(statsCaption, gridContainer);
+    }
+    if (statsCaption) {
+      statsCaption.textContent = resetStatsOnPromotion
+        ? 'Since your last promotion'
+        : '';
+      statsCaption.style.display = resetStatsOnPromotion ? 'block' : 'none';
+    }
   } else {
     if (statsSection) statsSection.style.display = 'none';
     gridContainer.innerHTML = '';


### PR DESCRIPTION
## Problem

Reported: *"the system where arrest and citations reset once someone is promoted seems to not be working — they've been promoted but the stats don't reset to 0."*

`public/js/rank-progress.js` — the officer-facing rank card included by **six** dashboards (police, command, department, dispatch, civ, ems) — was **missed** by the "reset stats on promotion" feature (#943, which updated `manage-ranks.js` and the settings modals only).

It rendered `currentValue` with **no label saying the number counts only since the member's last promotion**, and no lifetime context. So officers saw numbers that looked wrong with nothing explaining why — and the card disagreed with the mobile app, which was rendering `allTimeValue` for the same payload.

## Fix

- Read `resetStatsOnPromotion` from the rank-progress response.
- **Progress bars**: append `· N all-time` when the lifetime total differs from the since-promotion count.
- **Stats grid**: add a lifetime sub-line per tile, plus a **"Since your last promotion"** caption above the grid. The caption element is injected at runtime because this script is shared by six dashboards and none of them declare it — avoids touching six EJS templates.

Both additions are gated on the flag, so communities on the default (all-time) behavior see no change.

## Related

Paired with a mobile fix (police-cad-app, already on `production`) that corrected the inverse bug there — its "All Stats" grid always fell through to `allTimeValue` because it referenced a `metric.value` field the API never returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)