### PR TITLE
fix(records): page through every arrest report, not just the first 10

### DIFF
--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -684,3 +684,58 @@ export async function clearPendingDeletionTestCommunity(): Promise<void> {
     );
   });
 }
+
+// ---------------------------------------------------------------------------
+// Arrest reports
+// ---------------------------------------------------------------------------
+
+/**
+ * Seed `count` arrest reports against one arrestee.
+ *
+ * GET /api/v1/arrest-report/arrestee/{id} is paginated and defaults to 10 per
+ * page, so any surface that renders a civilian's full history needs more than
+ * one page of fixtures to prove it walks them all.
+ */
+export async function createTestArrestReports(opts: {
+  civilianId: string;
+  civilianName?: string;
+  count: number;
+  departmentId?: string;
+  reportPrefix?: string;
+}): Promise<string[]> {
+  const now = new Date();
+  const prefix = opts.reportPrefix ?? 'AR-PAGE';
+  const docs = Array.from({ length: opts.count }, (_, i) => ({
+    _id: new ObjectId(),
+    arrestReport: {
+      reportNumber: `${prefix}-${String(i + 1).padStart(3, '0')}`,
+      arrestDate: '01/15/2026',
+      arrestLocation: 'Test Highway',
+      arrestee: { id: opts.civilianId, name: opts.civilianName ?? 'E2E Arrestee' },
+      officer: { name: 'Test User', badgeNumber: 'T-1' },
+      officerID: TEST_USER_ID,
+      activeCommunityID: TEST_COMMUNITY_ID,
+      departmentId: opts.departmentId ?? '',
+      charges: `E2E Charge ${i + 1}`,
+      narrative: `E2E arrest report #${i + 1} for pagination coverage.`,
+      createdAt: new Date(now.getTime() + i * 1000),
+      updatedAt: new Date(now.getTime() + i * 1000),
+    },
+    __v: 0,
+  }));
+
+  await withDb(async (db) => {
+    await db.collection('arrestreports').insertMany(docs);
+  });
+
+  return docs.map((d) => d._id.toHexString());
+}
+
+/** Remove every arrest report seeded against an arrestee. */
+export async function deleteArrestReportsByArresteeId(civilianId: string): Promise<void> {
+  await withDb(async (db) => {
+    await db.collection('arrestreports').deleteMany({
+      'arrestReport.arrestee.id': civilianId,
+    });
+  });
+}

--- a/e2e/tests/dashboards/dd-civilian-records-pagination.spec.ts
+++ b/e2e/tests/dashboards/dd-civilian-records-pagination.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from '@playwright/test';
+import { TEST_CIVILIAN, TEST_CIVILIAN_ID, TEST_COMMUNITY_ID } from '../../helpers/seed';
+import {
+  addPoliceDepartment,
+  removeDepartmentById,
+  createTestArrestReports,
+  deleteArrestReportsByArresteeId,
+  encodeIdForUrl,
+} from '../../helpers/db';
+
+/**
+ * Regression guard for the arrest-report pagination bug.
+ *
+ * GET /api/v1/arrest-report/arrestee/{id} is paginated: it returns the full
+ * history size in `totalCount` but only one page in `data`, defaulting to 10
+ * per page. The civilian Records panel used to call it bare, so a civilian
+ * with more than 10 arrests could only ever see (and contest) the first 10.
+ *
+ * The fixture is deliberately larger than *both* the endpoint's 10-per-page
+ * default and the 25-per-page size the client walks with, so this fails if the
+ * walk regresses to a single request either way.
+ */
+const ARREST_COUNT = 30;
+
+test.describe('Department dashboard — civilian records pagination', { tag: '@auth' }, () => {
+  let deptId: string;
+  const civilianId = TEST_CIVILIAN_ID.toHexString();
+  const civilianName = `${TEST_CIVILIAN.firstName} ${TEST_CIVILIAN.lastName}`;
+
+  test.beforeEach(async () => {
+    // The seeded department carries no template components, so the Civilians
+    // panel wouldn't render. addPoliceDepartment enables createCivilians.
+    deptId = await addPoliceDepartment({ name: 'E2E Records PD' });
+    await deleteArrestReportsByArresteeId(civilianId);
+    await createTestArrestReports({
+      civilianId,
+      civilianName,
+      count: ARREST_COUNT,
+      departmentId: deptId,
+    });
+  });
+
+  test.afterEach(async () => {
+    await deleteArrestReportsByArresteeId(civilianId);
+    await removeDepartmentById(deptId);
+  });
+
+  test('Records tab lists every arrest report, not just the first page', async ({ page }) => {
+    const communityB64 = encodeIdForUrl(TEST_COMMUNITY_ID.toHexString());
+    const deptB64 = encodeIdForUrl(deptId);
+    await page.goto(
+      `/department-dashboard?dept=E2E%20Records%20PD&c=${encodeURIComponent(communityB64)}&d=${encodeURIComponent(deptB64)}`
+    );
+    await expect(page).not.toHaveURL(/\/login/);
+
+    // Open the Civilians panel. If the nav never renders, the dashboard didn't
+    // get its department data — skip rather than fail on an offline API.
+    const civNav = page.locator('#dd-nav-components .dd-nav-item[data-panel="createCivilians"]');
+    const navReady = await civNav
+      .waitFor({ state: 'visible', timeout: 15_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (!navReady) {
+      test.skip(true, 'Civilians panel nav not reachable — API may be offline');
+      return;
+    }
+    await civNav.click();
+
+    // Open the seeded civilian's detail overlay.
+    const civCard = page.locator(`.dd-civ-card[data-civ-id="${civilianId}"]`);
+    await expect(civCard).toBeVisible({ timeout: 15_000 });
+    await civCard.click();
+
+    // Records tab.
+    const recordsTab = page.locator('.dd-civ-tab[data-tab="records"]');
+    await expect(recordsTab).toBeVisible({ timeout: 10_000 });
+    await recordsTab.click();
+
+    // The Arrests filter chip is rendered from the accumulated list, so it is
+    // the count the user sees. Pre-fix this read "Arrests (10)".
+    const arrestFilter = page.locator('.dd-rec-filter-btn[data-filter="Arrest"]');
+    await expect(arrestFilter).toHaveText(`Arrests (${ARREST_COUNT})`, { timeout: 20_000 });
+
+    // Narrow to arrests only and confirm the list matches the count — the whole
+    // point of the bug was the two disagreeing.
+    await arrestFilter.click();
+    await expect(page.locator('#dd-civ-d-body .dd-civ-record')).toHaveCount(ARREST_COUNT);
+
+    // Every arrest must also be contestable; the old cap silently blocked
+    // civilians from contesting anything past the first page.
+    await expect(
+      page.locator('#dd-civ-d-body .dd-rec-contest-cb[data-item-type="arrest"]')
+    ).toHaveCount(ARREST_COUNT);
+
+    // Reports from the last page must actually be present, not just counted.
+    await expect(
+      page.locator('#dd-civ-d-body .dd-civ-record', { hasText: `E2E Charge ${ARREST_COUNT}` })
+    ).toHaveCount(1);
+  });
+});

--- a/public/js/dd-civilians.js
+++ b/public/js/dd-civilians.js
@@ -1689,6 +1689,15 @@
   var cachedArrests = null;
   var recordsFilter = 'all';
 
+  // The arrestee endpoint is paginated (10 per page by default), so a bare call
+  // silently caps the records list at one page. Walk every page — the filter
+  // counts and contest selection both need the complete history. Mirrors
+  // fetchArrests() in cd-person-search.js.
+  var ARREST_PAGE_LIMIT = 25;
+  // Runaway guard: only trips if the API stops honouring `page`, and sits far
+  // above any realistic arrest history.
+  var ARREST_MAX_PAGES = 40;
+
   function renderRecordsTab($body) {
     var c = currentCiv;
     if (!c) return;
@@ -1699,23 +1708,56 @@
 
     // Fetch arrest reports for this civilian
     var conf = cfg();
-    $.ajax({
-      url: conf.API_URL + '/api/v1/arrest-report/arrestee/' + c._id,
-      method: 'GET',
-      success: function (data) {
-        var raw = data.data || [];
-        cachedArrests = raw.map(function (r) {
-          var ar = r.arrestReport ? $.extend({ _id: r._id }, r.arrestReport) : r;
-          ar._recordSource = 'arrest';
-          return ar;
-        });
-        renderRecordsContent($body);
-      },
-      error: function () {
-        cachedArrests = [];
-        renderRecordsContent($body);
-      }
-    });
+    var civId = c._id;
+    var collected = [];
+    var totalCount = 0;
+
+    function stale() {
+      // The walk spans several requests; bail if the panel moved on to another
+      // civilian so we never render one civilian's records under another's.
+      return !currentCiv || currentCiv._id !== civId;
+    }
+
+    function finish() {
+      if (stale()) return;
+      cachedArrests = collected.map(function (r) {
+        var ar = r.arrestReport ? $.extend({ _id: r._id }, r.arrestReport) : r;
+        ar._recordSource = 'arrest';
+        return ar;
+      });
+      renderRecordsContent($body);
+    }
+
+    function fetchPage(page) {
+      $.ajax({
+        url: conf.API_URL + '/api/v1/arrest-report/arrestee/' + encodeURIComponent(civId) +
+          '?limit=' + ARREST_PAGE_LIMIT + '&page=' + page,
+        method: 'GET',
+        success: function (data) {
+          if (stale()) return;
+          var batch = data.data || [];
+          collected = collected.concat(batch);
+          if (typeof data.totalCount === 'number') totalCount = data.totalCount;
+
+          // A short page means we hit the end; the count check stops us as soon
+          // as we have everything even when the last page happens to be full.
+          var done = batch.length < ARREST_PAGE_LIMIT ||
+            collected.length >= totalCount ||
+            page + 1 >= ARREST_MAX_PAGES;
+          if (!done) {
+            fetchPage(page + 1);
+            return;
+          }
+          finish();
+        },
+        error: function () {
+          // Keep whatever pages already landed rather than dropping the lot.
+          finish();
+        }
+      });
+    }
+
+    fetchPage(0);
   }
 
   function renderRecordsContent($body) {

--- a/public/js/modern-dashboard.js
+++ b/public/js/modern-dashboard.js
@@ -5716,21 +5716,58 @@ $(document).on('click', '.criminal-toggle-btn', function() {
   }
 });
 
+// The arrestee endpoint is paginated (10 per page by default) and returns the
+// full history size in `totalCount`, so a bare call renders one page of rows
+// beside a much larger metric. Walk every page so the count, the list and
+// contest selection all see the same complete set. Mirrors fetchArrests() in
+// cd-person-search.js.
+const ARREST_REPORT_PAGE_LIMIT = 25;
+// Runaway guard: only trips if the API stops honouring `page`, and sits far
+// above any realistic arrest history.
+const ARREST_REPORT_MAX_PAGES = 40;
+
 function fetchArrestReportsForCiv(civId, cb) {
-  $.ajax({
-    url: `${API_URL}/api/v1/arrest-report/arrestee/${civId}`,
-    method: 'GET',
-    success: function(data) {
-      cachedArrestReports = (data.data || []).map(r => r.arrestReport ? { _id: r._id, ...r.arrestReport } : r);
-      cachedArrestReportsCount = data.totalCount || cachedArrestReports.length;
-      if (typeof cb === 'function') cb();
-    },
-    error: function() {
-      cachedArrestReports = [];
-      cachedArrestReportsCount = 0;
-      if (typeof cb === 'function') cb();
-    }
-  });
+  const collected = [];
+  let totalCount = 0;
+
+  const flatten = r => (r.arrestReport ? { _id: r._id, ...r.arrestReport } : r);
+
+  function finish(count) {
+    cachedArrestReports = collected.map(flatten);
+    cachedArrestReportsCount = count;
+    if (typeof cb === 'function') cb();
+  }
+
+  function fetchPage(page) {
+    $.ajax({
+      url: `${API_URL}/api/v1/arrest-report/arrestee/${civId}?limit=${ARREST_REPORT_PAGE_LIMIT}&page=${page}`,
+      method: 'GET',
+      success: function(data) {
+        const batch = data.data || [];
+        collected.push(...batch);
+        if (typeof data.totalCount === 'number') totalCount = data.totalCount;
+
+        // A short page means we hit the end; the count check stops us as soon
+        // as we have everything even when the last page happens to be full.
+        const done = batch.length < ARREST_REPORT_PAGE_LIMIT ||
+          collected.length >= totalCount ||
+          page + 1 >= ARREST_REPORT_MAX_PAGES;
+        if (!done) {
+          fetchPage(page + 1);
+          return;
+        }
+        finish(Math.max(totalCount, collected.length));
+      },
+      error: function() {
+        // Keep whatever pages already landed, but report the count we can
+        // actually render rather than the full total, so the metric never
+        // disagrees with the list.
+        finish(collected.length);
+      }
+    });
+  }
+
+  fetchPage(0);
 }
 
 // --- Medical Tab Functions ---

--- a/views/report-edit.ejs
+++ b/views/report-edit.ejs
@@ -1488,6 +1488,13 @@
         }, 200);
       }
 
+      // The arrestee endpoint is paginated (10 per page by default), so a single
+      // call quietly caps the picker at one page and hides older reports.
+      var ARREST_DRILL_PAGE_LIMIT = 25;
+      // Runaway guard: only trips if the API stops honouring `page`, and sits
+      // far above any realistic arrest history.
+      var ARREST_DRILL_MAX_PAGES = 40;
+
       // Step-2 fetch: load citations or arrest reports for a picked civilian.
       function loadDrillItems(tab, civilian) {
         var d = callPicker.drill[tab];
@@ -1516,18 +1523,45 @@
             })
             .catch(function () { d.loading = false; renderCallPicker(); });
         } else if (tab === 'arrestReport') {
-          fetch(apiUrl + '/api/v1/arrest-report/arrestee/' + encodeURIComponent(civilian._id) + '?limit=50&page=0', { headers: authHeaders() })
-            .then(function (r) { return r.ok ? r.json() : { data: [] }; })
-            .then(function (j) {
-              var rows = (j && j.data) || [];
-              rows.sort(function (a, b) {
-                var aT = (a.arrestReport && a.arrestReport.createdAt) ? new Date(a.arrestReport.createdAt).getTime() : 0;
-                var bT = (b.arrestReport && b.arrestReport.createdAt) ? new Date(b.arrestReport.createdAt).getTime() : 0;
-                return bT - aT;
-              });
-              d.items = rows; d.loading = false; renderCallPicker();
-            })
-            .catch(function () { d.loading = false; renderCallPicker(); });
+          // Walk every page so the picker offers the civilian's full history.
+          var rows = [];
+          var totalCount = 0;
+
+          var finishArrests = function () {
+            if (d.civilian !== civilian) return; // a newer pick has superseded this
+            rows.sort(function (a, b) {
+              var aT = (a.arrestReport && a.arrestReport.createdAt) ? new Date(a.arrestReport.createdAt).getTime() : 0;
+              var bT = (b.arrestReport && b.arrestReport.createdAt) ? new Date(b.arrestReport.createdAt).getTime() : 0;
+              return bT - aT;
+            });
+            d.items = rows; d.loading = false; renderCallPicker();
+          };
+
+          var fetchArrestPage = function (page) {
+            fetch(apiUrl + '/api/v1/arrest-report/arrestee/' + encodeURIComponent(civilian._id) +
+              '?limit=' + ARREST_DRILL_PAGE_LIMIT + '&page=' + page, { headers: authHeaders() })
+              .then(function (r) { return r.ok ? r.json() : null; })
+              .then(function (j) {
+                if (d.civilian !== civilian) return;
+                var batch = (j && j.data) || [];
+                rows = rows.concat(batch);
+                if (j && typeof j.totalCount === 'number') totalCount = j.totalCount;
+
+                // A short page means we hit the end; the count check stops us as
+                // soon as we have everything even when the last page is full.
+                if (!j || batch.length < ARREST_DRILL_PAGE_LIMIT ||
+                    rows.length >= totalCount ||
+                    page + 1 >= ARREST_DRILL_MAX_PAGES) {
+                  finishArrests();
+                  return;
+                }
+                fetchArrestPage(page + 1);
+              })
+              // Keep whatever pages already landed rather than dropping the lot.
+              .catch(function () { finishArrests(); });
+          };
+
+          fetchArrestPage(0);
         }
       }
 


### PR DESCRIPTION
## Problem

`GET /api/v1/arrest-report/arrestee/{id}` is paginated and defaults to **10 per page**. It returns `{ page, totalCount, data }` where `totalCount` is the civilian's full history but `data` is only the current page.

Three website surfaces called it bare (or with a fixed cap), so a civilian with more than 10 arrest reports could only ever see — and contest — the first 10. Same defect already fixed on mobile (`police-cad-app` f9a1f60) and hardened on the API in Linesmerrill/police-cad-api#173, which added the missing `Sort` so multi-page walks are stable.

| Surface | Before | Symptom |
|---|---|---|
| [modern-dashboard.js:5721](https://github.com/Linesmerrill/police-cad/blob/main/public/js/modern-dashboard.js#L5721) `fetchArrestReportsForCiv()` | no `limit`/`page` | set the metric card from `totalCount` while the list held one page — the counter said 16, the list showed 10 |
| [dd-civilians.js:1703](https://github.com/Linesmerrill/police-cad/blob/main/public/js/dd-civilians.js#L1703) Records panel | no `limit`/`page` | `cachedArrests` capped at one page, which also capped what could be contested |
| [report-edit.ejs:1519](https://github.com/Linesmerrill/police-cad/blob/main/views/report-edit.ejs#L1519) arrest picker | `?limit=50&page=0` | hard cap at 50 rather than paging |

## Fix

All three now walk every page, following the existing `fetchArrests()` pattern in `cd-person-search.js` — **no arbitrary high limit**. Each walk:

- requests 25 per page starting at `page=0` (the endpoint is 0-based)
- stops on a short page *or* once `totalCount` is reached, so an exact-multiple last page doesn't cost an extra request
- keeps whatever pages already landed if a request fails mid-walk, and reports a count matching what it can actually render — never re-creating the count-vs-list mismatch
- carries a max-pages guard that only trips if the API stops honouring `page`

The two civilian-scoped walks additionally discard their results if the panel moves to another civilian mid-walk, so one civilian's records can't paint under another's — a wider window now that the walk spans several round-trips.

`details-modal.js` is deliberately left alone: its `limit=3` backs a real prev/next pager, not a full-history render.

## Verification

- Extracted each edited region verbatim from source and ran it against a stubbed API — **31 checks pass**, covering: 16 reports render 16 with a matching count (the reported bug), multi-page accumulation with no duplicates, exact-multiple page sizes, empty history, mid-walk failure, civilian-switch mid-walk, an API that ignores `page`, and a missing `totalCount`.
- `npx next lint` — 0 errors.
- `npx tsc --noEmit` — clean.
- EJS template compiles; both edited `.js` files pass `node --check`.

## Tests

Adds `e2e/tests/dashboards/dd-civilian-records-pagination.spec.ts` — seeds **30** arrest reports (more than both the endpoint's 10-per-page default *and* the 25-per-page walk size, so it fails if either regresses to a single request) and asserts the Records panel's Arrests chip, the rendered rows, and the contest checkboxes all reach 30, including a report from the final page.

New `db.ts` helpers: `createTestArrestReports` / `deleteArrestReportsByArresteeId`.

## Follow-up (not in this PR)

`dd-civilians.js` fetches vehicles ([:1304](https://github.com/Linesmerrill/police-cad/blob/main/public/js/dd-civilians.js#L1304)) and firearms ([:1530](https://github.com/Linesmerrill/police-cad/blob/main/public/js/dd-civilians.js#L1530)) with `limit=50&page=0` and then filters client-side to the linked ones — a user with more than 50 would lose linked records the same way. Different endpoints, so left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)