### PR TITLE
fix(vehicles): one shared flag normalizer instead of five local toBool copies

### DIFF
--- a/public/js/cd-person-search.js
+++ b/public/js/cd-person-search.js
@@ -62,6 +62,14 @@
   }
 
   /** Normalize boolean-ish API values. */
+  /**
+   * Vehicle flags have per-field polarity in the legacy encoding, so they go
+   * through the shared helper rather than the local toBool() below, which is
+   * only safe for the plain booleans (probation/parole).
+   * See /static/js/vehicle-flags.js.
+   */
+  var Flags = window.VehicleFlags;
+
   function toBool(val) {
     return val === true || val === 1 || val === '1' || val === 'true';
   }
@@ -468,9 +476,9 @@
         var plate = v.plate || 'N/A';
         var vMakeModel = [v.year, v.make, v.model].filter(Boolean).join(' ');
         var vIdx = 'veh-' + pid + '-' + j;
-        var vRegOk = toBool(v.validRegistration);
-        var vInsOk = toBool(v.validInsurance);
-        var vStolen = toBool(v.isStolen);
+        var vRegOk = Flags.registrationValid(v);
+        var vInsOk = Flags.insuranceValid(v);
+        var vStolen = Flags.stolen(v);
         html += '<div class="cd-ps-sub-item" onclick="cdPsToggleSub(\'' + vIdx + '\')">' +
           '<div class="cd-ps-sub-item-header" style="gap:0.625rem;">' +
             (v.image
@@ -500,7 +508,7 @@
               '<div class="cd-ps-detail-field"><div class="cd-ps-detail-label">Registration</div><div class="cd-ps-detail-value" style="color:' + (vRegOk ? 'var(--cd-green)' : 'var(--cd-amber)') + ';font-weight:600;">' + (vRegOk ? 'Valid' : 'Invalid') + '</div></div>' +
               '<div class="cd-ps-detail-field"><div class="cd-ps-detail-label">Insurance</div><div class="cd-ps-detail-value" style="color:' + (vInsOk ? 'var(--cd-green)' : 'var(--cd-amber)') + ';font-weight:600;">' + (vInsOk ? 'Valid' : 'Invalid') + '</div></div>' +
               '<div class="cd-ps-detail-field"><div class="cd-ps-detail-label">Stolen</div><div class="cd-ps-detail-value" style="color:' + (vStolen ? 'var(--cd-red)' : 'var(--cd-green)') + ';font-weight:600;">' + (vStolen ? 'Yes' : 'No') + '</div></div>' +
-              '<div class="cd-ps-detail-field"><div class="cd-ps-detail-label">Exempt</div><div class="cd-ps-detail-value" style="' + (toBool(v.isExempt) ? 'color:var(--cd-accent);font-weight:600;' : '') + '">' + (toBool(v.isExempt) ? 'Yes' : 'No') + '</div></div>' +
+              '<div class="cd-ps-detail-field"><div class="cd-ps-detail-label">Exempt</div><div class="cd-ps-detail-value" style="' + (Flags.exempt(v) ? 'color:var(--cd-accent);font-weight:600;' : '') + '">' + (Flags.exempt(v) ? 'Yes' : 'No') + '</div></div>' +
             '</div>' +
           '</div>' +
         '</div>';

--- a/public/js/cd-vehicle-search.js
+++ b/public/js/cd-vehicle-search.js
@@ -37,10 +37,12 @@
   function esc(s) { return window.esc ? window.esc(s) : String(s || '').replace(/[&<>"']/g, function (c) { return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]; }); }
   function toast(msg, type) { if (window.ddToast) window.ddToast(msg, type); }
 
-  /** Normalize boolean-ish API values. */
-  function toBool(val) {
-    return val === true || val === 1 || val === '1' || val === 'true';
-  }
+  /**
+   * Vehicle flag helpers. A single local toBool() used to serve all four
+   * flags, which inverted isStolen — the legacy numeric encoding is a select
+   * index, not a boolean. See /static/js/vehicle-flags.js.
+   */
+  var Flags = window.VehicleFlags;
 
   /** Flatten { _id, vehicle: {...} } → merged object */
   function flatten(item) {
@@ -173,9 +175,9 @@
     var model = esc(veh.model || '');
     var desc = [color, model].filter(Boolean).join(' ');
     var ownerName = esc(veh._resolvedOwner || veh.registeredOwner || '');
-    var isStolen = toBool(veh.isStolen);
-    var invalidReg = !toBool(veh.validRegistration);
-    var invalidIns = !toBool(veh.validInsurance);
+    var isStolen = Flags.stolen(veh);
+    var invalidReg = !Flags.registrationValid(veh);
+    var invalidIns = !Flags.insuranceValid(veh);
     var isExpanded = state.expandedId === veh._id;
 
     var sub = [];
@@ -210,7 +212,7 @@
   /* ───────────────────────── Build detail HTML ───────────────────────── */
 
   function buildDetailHTML(veh) {
-    var isStolen = toBool(veh.isStolen);
+    var isStolen = Flags.stolen(veh);
     return (
       '<div class="cd-vs-detail-inner">' +
         '<div class="cd-vs-detail-grid">' +
@@ -224,9 +226,9 @@
           detailField('Plate State', veh.licensePlateState) +
           '<div class="cd-vs-detail-field"><div class="cd-vs-detail-label">Owner</div><div class="cd-vs-detail-value" id="cd-vs-owner-' + esc(veh._id) + '">' + (veh.registeredOwner ? '<a href="#" onclick="event.preventDefault();event.stopPropagation();cdVsSearchOwner(\'' + esc(veh.registeredOwner.replace(/'/g, "\\'")) + '\')" style="color:var(--cd-accent);text-decoration:none;">' + esc(veh.registeredOwner) + '</a>' : '') + (veh.linkedCivilianID && !veh.registeredOwner ? '<i class="fa fa-circle-notch fa-spin" style="font-size:0.625rem;color:var(--cd-text-dim);"></i>' : (!veh.registeredOwner && !veh.linkedCivilianID ? 'N/A' : '')) + '</div></div>' +
           detailField('Stolen', isStolen ? 'Yes' : 'No', isStolen ? 'var(--cd-red)' : 'var(--cd-green)') +
-          detailField('Exempt', toBool(veh.isExempt) ? 'Yes' : 'No', toBool(veh.isExempt) ? 'var(--cd-accent)' : '') +
-          detailField('Registration', toBool(veh.validRegistration) ? 'Valid' : 'Invalid', toBool(veh.validRegistration) ? 'var(--cd-green)' : 'var(--cd-amber)') +
-          detailField('Insurance', toBool(veh.validInsurance) ? 'Valid' : 'Invalid', toBool(veh.validInsurance) ? 'var(--cd-green)' : 'var(--cd-amber)') +
+          detailField('Exempt', Flags.exempt(veh) ? 'Yes' : 'No', Flags.exempt(veh) ? 'var(--cd-accent)' : '') +
+          detailField('Registration', Flags.registrationValid(veh) ? 'Valid' : 'Invalid', Flags.registrationValid(veh) ? 'var(--cd-green)' : 'var(--cd-amber)') +
+          detailField('Insurance', Flags.insuranceValid(veh) ? 'Valid' : 'Invalid', Flags.insuranceValid(veh) ? 'var(--cd-green)' : 'var(--cd-amber)') +
         '</div>' +
         '<div style="margin-top:0.75rem;padding-top:0.625rem;border-top:1px solid var(--cd-glass-border);">' +
           '<button style="display:inline-flex;align-items:center;gap:0.375rem;padding:0.4rem 0.75rem;border-radius:var(--cd-radius-sm);font-family:Outfit,sans-serif;font-size:0.6875rem;font-weight:600;border:1px solid;cursor:pointer;transition:all 0.15s;' +

--- a/public/js/community-details.js
+++ b/public/js/community-details.js
@@ -2264,9 +2264,11 @@ function updateDepartmentJoinButton(departmentId, status) {
       const plate = v.plate || 'N/A';
       const username = user.username ? `@${user.username}` : '';
       const createdAt = v.createdAt ? new Date(v.createdAt).toLocaleDateString() : '';
-      const isStolen = v.isStolen === 'true' || v.isStolen === true;
-      const validReg = v.validRegistration === 'true' || v.validRegistration === true;
-      const validIns = v.validInsurance === 'true' || v.validInsurance === true;
+      // Most vehicles still use the legacy encoding, where each flag has its
+      // own polarity. See /static/js/vehicle-flags.js.
+      const isStolen = window.VehicleFlags.stolen(v);
+      const validReg = window.VehicleFlags.registrationValid(v);
+      const validIns = window.VehicleFlags.insuranceValid(v);
 
       return `
         <div style="background:#1e2028; border:1px solid #4a5568; border-radius:12px; padding:1.5rem; margin-bottom:1rem; transition:all 0.2s; cursor:pointer;" onclick="editVehicle('${item._id}')">
@@ -2385,9 +2387,9 @@ function updateDepartmentJoinButton(departmentId, status) {
       document.getElementById('editVehicleModel').value = v.model || '';
       document.getElementById('editVehicleYear').value = v.year || '';
       document.getElementById('editVehicleColor').value = v.color || '';
-      document.getElementById('editVehicleValidRegistration').checked = v.validRegistration === 'true' || v.validRegistration === true;
-      document.getElementById('editVehicleValidInsurance').checked = v.validInsurance === 'true' || v.validInsurance === true;
-      document.getElementById('editVehicleIsStolen').checked = v.isStolen === 'true' || v.isStolen === true;
+      document.getElementById('editVehicleValidRegistration').checked = window.VehicleFlags.registrationValid(v);
+      document.getElementById('editVehicleValidInsurance').checked = window.VehicleFlags.insuranceValid(v);
+      document.getElementById('editVehicleIsStolen').checked = window.VehicleFlags.stolen(v);
 
       document.getElementById('editVehicleModal').style.display = 'flex';
 

--- a/public/js/dd-civilians.js
+++ b/public/js/dd-civilians.js
@@ -1347,7 +1347,7 @@
           var metaStr = meta.length ? meta.join(' &middot; ') : 'No details';
 
           // Stolen indicator changes icon color
-          var isStolen = v.isStolen === true || v.isStolen === 'true';
+          var isStolen = window.VehicleFlags.stolen(v);
           var iconColor = isStolen ? 'var(--dd-red)' : 'var(--dd-green)';
           var stolenBadge = isStolen ? ' <span style="color:var(--dd-red);font-size:0.6rem;font-weight:700;text-transform:uppercase;margin-left:0.3rem;">STOLEN</span>' : '';
 
@@ -1378,7 +1378,9 @@
   }
 
   function buildVehicleCard(v, mode) {
-    var isStolen = v.isStolen === true || v.isStolen === 'true';
+    // Flags go through the shared helper: most records still use the legacy
+    // encoding, where each field has its own polarity. /static/js/vehicle-flags.js
+    var isStolen = window.VehicleFlags.stolen(v);
     var iconClass = isStolen ? 'veh-stolen' : 'veh-ok';
     var sep = '<span class="dd-veh-sep">&middot;</span>';
 
@@ -1394,9 +1396,9 @@
     // Status badges
     var badges = '';
     if (isStolen) badges += '<span class="dd-veh-badge badge-stolen"><i class="fa fa-exclamation-triangle"></i> Stolen</span>';
-    if (v.isExempt === true || v.isExempt === 'true') badges += '<span class="dd-veh-badge badge-exempt"><i class="fa fa-shield"></i> Exempt</span>';
-    if (v.validRegistration === false || v.validRegistration === 'false') badges += '<span class="dd-veh-badge badge-reg"><i class="fa fa-file-circle-xmark"></i> Invalid Reg</span>';
-    if (v.validInsurance === false || v.validInsurance === 'false') badges += '<span class="dd-veh-badge badge-ins"><i class="fa fa-file-shield"></i> No Insurance</span>';
+    if (window.VehicleFlags.exempt(v)) badges += '<span class="dd-veh-badge badge-exempt"><i class="fa fa-shield"></i> Exempt</span>';
+    if (!window.VehicleFlags.registrationValid(v)) badges += '<span class="dd-veh-badge badge-reg"><i class="fa fa-file-circle-xmark"></i> Invalid Reg</span>';
+    if (!window.VehicleFlags.insuranceValid(v)) badges += '<span class="dd-veh-badge badge-ins"><i class="fa fa-file-shield"></i> No Insurance</span>';
 
     // Action button
     var action = '';

--- a/public/js/dd-vehicles.js
+++ b/public/js/dd-vehicles.js
@@ -39,21 +39,16 @@
   }
 
   /**
-   * Normalize boolean-ish API values.
-   * The backend stores some booleans as strings ("1"/"2", "true"/"false")
-   * or numbers (1/2). Normalize to a real boolean.
+   * Vehicle flag helpers. These used to be a single local toBool() applied to
+   * all four flags, which silently inverted isStolen/isExempt — the legacy
+   * numeric encoding is a select index, not a boolean, so its polarity differs
+   * per field. See /static/js/vehicle-flags.js.
    */
-  function toBool(val) {
-    if (val === true || val === 1 || val === '1' || val === 'true') return true;
-    return false;
-  }
+  var Flags = window.VehicleFlags;
 
-  /**
-   * Convert a boolean back to the string the API expects.
-   * "1" = true, "2" = false  (matches existing data convention).
-   */
+  /** Writes now use "true"/"false"; the numeric encoding is read-only legacy. */
   function boolToApi(val) {
-    return val ? '1' : '2';
+    return Flags.toApi(val);
   }
 
   function generateVin() {
@@ -412,16 +407,16 @@
 
       // Badges
       var badges = '';
-      if (toBool(d.isStolen)) {
+      if (Flags.stolen(d)) {
         badges += '<span class="dd-veh-badge dd-veh-badge-red">Stolen</span>';
       }
-      if (toBool(d.isExempt)) {
+      if (Flags.exempt(d)) {
         badges += '<span class="dd-veh-badge dd-veh-badge-blue">Exempt</span>';
       }
-      if (!toBool(d.validRegistration)) {
+      if (!Flags.registrationValid(d)) {
         badges += '<span class="dd-veh-badge dd-veh-badge-red">Invalid Registration</span>';
       }
-      if (!toBool(d.validInsurance)) {
+      if (!Flags.insuranceValid(d)) {
         badges += '<span class="dd-veh-badge dd-veh-badge-red">Invalid Insurance</span>';
       }
 
@@ -604,10 +599,10 @@
       $('#dd-veh-d-photo-img').hide();
       $('#dd-veh-d-photo-icon').attr('class', 'fa fa-car dd-veh-photo-icon').show();
     }
-    $('#dd-veh-d-validReg').prop('checked', toBool(d.validRegistration));
-    $('#dd-veh-d-validIns').prop('checked', toBool(d.validInsurance));
-    $('#dd-veh-d-stolen').prop('checked', toBool(d.isStolen));
-    $('#dd-veh-d-exempt').prop('checked', toBool(d.isExempt));
+    $('#dd-veh-d-validReg').prop('checked', Flags.registrationValid(d));
+    $('#dd-veh-d-validIns').prop('checked', Flags.insuranceValid(d));
+    $('#dd-veh-d-stolen').prop('checked', Flags.stolen(d));
+    $('#dd-veh-d-exempt').prop('checked', Flags.exempt(d));
 
     $('#dd-veh-detail-overlay').addClass('dd-civ-visible');
   }

--- a/public/js/details-modal.js
+++ b/public/js/details-modal.js
@@ -510,16 +510,16 @@ $(document).ready(function () {
           data.year || "N/A"
         }</div>
         <div class="mb-2"><span class="text-gray">Registration:</span> ${
-          (data.validRegistration === 'true' || data.validRegistration === '1') ? '<span class="badge-stolen" style="background-color: #10b981; color: white;">Valid</span>' : '<span class="badge-stolen" style="background-color: #ef4444; color: white;">Invalid</span>'
+          window.VehicleFlags.registrationValid(data) ? '<span class="badge-stolen" style="background-color: #10b981; color: white;">Valid</span>' : '<span class="badge-stolen" style="background-color: #ef4444; color: white;">Invalid</span>'
         }</div>
         <div class="mb-2"><span class="text-gray">Insurance:</span> ${
-          (data.validInsurance === 'true' || data.validInsurance === '1') ? '<span class="badge-stolen" style="background-color: #10b981; color: white;">Valid</span>' : '<span class="badge-stolen" style="background-color: #ef4444; color: white;">Invalid</span>'
+          window.VehicleFlags.insuranceValid(data) ? '<span class="badge-stolen" style="background-color: #10b981; color: white;">Valid</span>' : '<span class="badge-stolen" style="background-color: #ef4444; color: white;">Invalid</span>'
         }</div>
         <div class="mb-2"><span class="text-gray">Stolen:</span> ${
-          (data.isStolen === 'true' || data.isStolen === '2') ? '<span class="badge-stolen">Yes</span>' : '<span class="badge-stolen" style="background-color: #10b981; color: white;">No</span>'
+          window.VehicleFlags.stolen(data) ? '<span class="badge-stolen">Yes</span>' : '<span class="badge-stolen" style="background-color: #10b981; color: white;">No</span>'
         }</div>
         <div class="mb-2"><span class="text-gray">Exempt:</span> ${
-          (data.isExempt === 'true') ? '<span class="badge-stolen" style="background-color: #3b82f6; color: white;">Yes</span>' : '<span class="badge-stolen" style="background-color: #6b7280; color: white;">No</span>'
+          window.VehicleFlags.exempt(data) ? '<span class="badge-stolen" style="background-color: #3b82f6; color: white;">Yes</span>' : '<span class="badge-stolen" style="background-color: #6b7280; color: white;">No</span>'
         }</div>
         <div class="mb-2"><span class="text-gray">Registered Owner:</span> ${
           owner
@@ -737,7 +737,7 @@ $(document).ready(function () {
     if (currentType === "Vehicle" || currentType === "Firearm") {
       actionsHtml += `
         <button class="btn btn-warning btn-block mb-2 action-button" data-action="Report Stolen" data-stolen="${data.isStolen || 'false'}">
-          ${(data.isStolen === 'true' || data.isStolen === '2') ? "Mark as Not Stolen" : "Report Stolen"}
+          ${/* firearms only ever used "true"/"false", which this helper handles first */ window.VehicleFlags.stolen(data) ? "Mark as Not Stolen" : "Report Stolen"}
         </button>
       `;
     } else if (currentType === "License") {
@@ -794,7 +794,7 @@ $(document).ready(function () {
 
   // Handle report stolen
   function handleReportStolen(itemId, isStolen) {
-    const isCurrentlyStolen = isStolen === true || isStolen === 'true' || isStolen === '2';
+    const isCurrentlyStolen = window.VehicleFlags.stolen({ isStolen: isStolen });
     const newStolenStatus = isCurrentlyStolen ? "false" : "true"; // Use string "true"/"false" system
     const actionText = isCurrentlyStolen ? "mark as not stolen" : "report as stolen";
     const successText = isCurrentlyStolen ? "marked as not stolen" : "reported as stolen";
@@ -1801,9 +1801,9 @@ $(document).ready(function () {
             <p class="text-gray mb-0">Make: ${vehicle.make || 'N/A'}</p>
             <p class="text-gray mb-0">Year: ${vehicle.year || 'N/A'}</p>
             <p class="text-gray mb-0">VIN: ${vehicle.vin || 'N/A'}</p>
-            ${(vehicle.isStolen === 'true' || vehicle.isStolen === '2') ? '<span class="badge badge-stolen">STOLEN</span>' : ''}
-            ${(vehicle.validRegistration === 'false' || vehicle.validRegistration === '2') ? '<span class="badge badge-stolen" style="background-color: #ef4444; color: white;">INVALID REG</span>' : ''}
-            ${(vehicle.validInsurance === 'false' || vehicle.validInsurance === '2') ? '<span class="badge badge-stolen" style="background-color: #ef4444; color: white;">INVALID INS</span>' : ''}
+            ${window.VehicleFlags.stolen(vehicle) ? '<span class="badge badge-stolen">STOLEN</span>' : ''}
+            ${!window.VehicleFlags.registrationValid(vehicle) ? '<span class="badge badge-stolen" style="background-color: #ef4444; color: white;">INVALID REG</span>' : ''}
+            ${!window.VehicleFlags.insuranceValid(vehicle) ? '<span class="badge badge-stolen" style="background-color: #ef4444; color: white;">INVALID INS</span>' : ''}
           </div>
         `;
       });

--- a/public/js/modern-dashboard.js
+++ b/public/js/modern-dashboard.js
@@ -908,10 +908,10 @@ function renderVehicles(vehicles) {
                     <p><strong>Make:</strong> ${vehData.make || 'N/A'}</p>
                     <p><strong>Model:</strong> ${vehData.model || 'N/A'}</p>
                     <p><strong>Year:</strong> ${vehData.year || 'N/A'}</p>
-                    ${(vehData.isStolen === 'true' || vehData.isStolen === '2') ? '<p style="color:#ef4444; font-weight:bold;"><i class="fa fa-exclamation-triangle"></i> STOLEN</p>' : ''}
-                    ${(vehData.isExempt === 'true') ? '<p style="color:#3b82f6; font-weight:bold;"><i class="fa fa-shield"></i> EXEMPT</p>' : ''}
-                    ${(vehData.validRegistration === 'false' || vehData.validRegistration === '2') ? '<p style="color:#ef4444; font-weight:bold;"><i class="fa fa-exclamation-triangle"></i> INVALID REGISTRATION</p>' : ''}
-                    ${(vehData.validInsurance === 'false' || vehData.validInsurance === '2') ? '<p style="color:#ef4444; font-weight:bold;"><i class="fa fa-exclamation-triangle"></i> INVALID INSURANCE</p>' : ''}
+                    ${window.VehicleFlags.stolen(vehData) ? '<p style="color:#ef4444; font-weight:bold;"><i class="fa fa-exclamation-triangle"></i> STOLEN</p>' : ''}
+                    ${window.VehicleFlags.exempt(vehData) ? '<p style="color:#3b82f6; font-weight:bold;"><i class="fa fa-shield"></i> EXEMPT</p>' : ''}
+                    ${!window.VehicleFlags.registrationValid(vehData) ? '<p style="color:#ef4444; font-weight:bold;"><i class="fa fa-exclamation-triangle"></i> INVALID REGISTRATION</p>' : ''}
+                    ${!window.VehicleFlags.insuranceValid(vehData) ? '<p style="color:#ef4444; font-weight:bold;"><i class="fa fa-exclamation-triangle"></i> INVALID INSURANCE</p>' : ''}
                 </div>
             </div>
         `;
@@ -3823,10 +3823,10 @@ function renderLinkedVehicles(vehicles, civilianId) {
                 <div class="card-content">
                     <p>Type: ${vehicle?.vehicle?.type || 'Unknown'}</p>
                     <p>Year: ${vehicle?.vehicle?.year || 'Unknown'}</p>
-                    ${(vehicle?.vehicle?.isStolen === 'true' || vehicle?.vehicle?.isStolen === '2') ? '<p style="color:#ef4444; font-weight:bold;"><i class="fa fa-exclamation-triangle"></i> STOLEN</p>' : ''}
-                    ${(vehicle?.vehicle?.isExempt === 'true') ? '<p style="color:#3b82f6; font-weight:bold;"><i class="fa fa-shield"></i> EXEMPT</p>' : ''}
-                    ${(vehicle?.vehicle?.validRegistration === 'false' || vehicle?.vehicle?.validRegistration === '2') ? '<p style="color:#ef4444; font-weight:bold;"><i class="fa fa-exclamation-triangle"></i> INVALID REGISTRATION</p>' : ''}
-                    ${(vehicle?.vehicle?.validInsurance === 'false' || vehicle?.vehicle?.validInsurance === '2') ? '<p style="color:#ef4444; font-weight:bold;"><i class="fa fa-exclamation-triangle"></i> INVALID INSURANCE</p>' : ''}
+                    ${window.VehicleFlags.stolen(vehicle?.vehicle) ? '<p style="color:#ef4444; font-weight:bold;"><i class="fa fa-exclamation-triangle"></i> STOLEN</p>' : ''}
+                    ${window.VehicleFlags.exempt(vehicle?.vehicle) ? '<p style="color:#3b82f6; font-weight:bold;"><i class="fa fa-shield"></i> EXEMPT</p>' : ''}
+                    ${!window.VehicleFlags.registrationValid(vehicle?.vehicle) ? '<p style="color:#ef4444; font-weight:bold;"><i class="fa fa-exclamation-triangle"></i> INVALID REGISTRATION</p>' : ''}
+                    ${!window.VehicleFlags.insuranceValid(vehicle?.vehicle) ? '<p style="color:#ef4444; font-weight:bold;"><i class="fa fa-exclamation-triangle"></i> INVALID INSURANCE</p>' : ''}
                     ${linkedInfo}
                     ${buttonHtml}
                 </div>

--- a/public/js/plate-database.js
+++ b/public/js/plate-database.js
@@ -46,9 +46,9 @@ function vehicleSearchPoliceForm() {
                     <h4 id="search-results-vehicles-thumbnail-plate-${res[i]._id}" class="color-white license-plate">#${escapeHtml(res[i].vehicle.plate)})</h4>
                     <h5 id="search-results-vehicles-thumbnail-color-model-${res[i]._id}" class="color-white">${escapeHtml(res[i].vehicle.color)} ${escapeHtml(res[i].vehicle.model)}</h5>
                     <h5 id="search-results-vehicles-thumbnail-owner-${res[i]._id}" class="color-white capitalize">${escapeHtml(res[i].vehicle.registeredOwner)}</h5>
-                    ${(res[i].vehicle.isStolen === 'true' || res[i].vehicle.isStolen === '2') ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> STOLEN</p>' : ''}
-                    ${(res[i].vehicle.validRegistration === 'false' || res[i].vehicle.validRegistration === '2') ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID REG</p>' : ''}
-                    ${(res[i].vehicle.validInsurance === 'false' || res[i].vehicle.validInsurance === '2') ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID INS</p>' : ''}
+                    ${window.VehicleFlags.stolen(res[i].vehicle) ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> STOLEN</p>' : ''}
+                    ${!window.VehicleFlags.registrationValid(res[i].vehicle) ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID REG</p>' : ''}
+                    ${!window.VehicleFlags.insuranceValid(res[i].vehicle) ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID INS</p>' : ''}
                   </div>
                 </div> 
               </div>`
@@ -115,7 +115,7 @@ function populateVehSocketDetails(res) {
   $("#modelVeh").val(res.vehicle.model);
   $("#colorView").val(res.vehicle.color);
   // Convert to string "true"/"false" system for registration
-  const isValidRegistration = res.vehicle.validRegistration === "1" || res.vehicle.validRegistration === "true";
+  const isValidRegistration = window.VehicleFlags.registrationValid(res.vehicle);
   $("#validRegView").val(isValidRegistration ? "true" : "false");
   if (!isValidRegistration) {
     //if the vehicle is not registered, show the is invalid alert
@@ -125,7 +125,7 @@ function populateVehSocketDetails(res) {
   }
   
   // Convert to string "true"/"false" system for insurance
-  const isValidInsurance = res.vehicle.validInsurance === "1" || res.vehicle.validInsurance === "true";
+  const isValidInsurance = window.VehicleFlags.insuranceValid(res.vehicle);
   $("#validInsView").val(isValidInsurance ? "true" : "false");
   if (!isValidInsurance) {
     //if the vehicle is not insured, show the is invalid alert
@@ -135,7 +135,7 @@ function populateVehSocketDetails(res) {
   }
   $("#roVeh").val(res.vehicle.registeredOwner);
   // Convert to string "true"/"false" system
-  const isStolen = res.vehicle.isStolen === "2" || res.vehicle.isStolen === "true";
+  const isStolen = window.VehicleFlags.stolen(res.vehicle);
   $("#stolenView").val(isStolen ? "true" : "false");
   if (isStolen) {
     //if the vehicle is stolen, hide the mark stolen button
@@ -184,9 +184,9 @@ function getVehicles() {
             <div class="caption">
               <h4 class="color-white license-plate">#${escapeHtml(res[i].vehicle.plate)})</h4>
               <h5 class="color-white">${escapeHtml(res[i].vehicle.color)} ${escapeHtml(res[i].vehicle.model)}</h5>
-              ${(res[i].vehicle.isStolen === 'true' || res[i].vehicle.isStolen === '2') ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> STOLEN</p>' : ''}
-              ${(res[i].vehicle.validRegistration === 'false' || res[i].vehicle.validRegistration === '2') ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID REG</p>' : ''}
-              ${(res[i].vehicle.validInsurance === 'false' || res[i].vehicle.validInsurance === '2') ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID INS</p>' : ''}
+              ${window.VehicleFlags.stolen(res[i].vehicle) ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> STOLEN</p>' : ''}
+              ${!window.VehicleFlags.registrationValid(res[i].vehicle) ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID REG</p>' : ''}
+              ${!window.VehicleFlags.insuranceValid(res[i].vehicle) ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID INS</p>' : ''}
             </div>
           </div>
         </div>`
@@ -230,9 +230,9 @@ function getNextVehPage() {
           <div class="caption">
             <h4 class="color-white license-plate">#${escapeHtml(res[i].vehicle.plate)})</h4>
             <h5 class="color-white">${escapeHtml(res[i].vehicle.color)} ${escapeHtml(res[i].vehicle.model)}</h5>
-            ${(res[i].vehicle.isStolen === 'true' || res[i].vehicle.isStolen === '2') ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> STOLEN</p>' : ''}
-            ${(res[i].vehicle.validRegistration === 'false' || res[i].vehicle.validRegistration === '2') ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID REG</p>' : ''}
-            ${(res[i].vehicle.validInsurance === 'false' || res[i].vehicle.validInsurance === '2') ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID INS</p>' : ''}
+            ${window.VehicleFlags.stolen(res[i].vehicle) ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> STOLEN</p>' : ''}
+            ${!window.VehicleFlags.registrationValid(res[i].vehicle) ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID REG</p>' : ''}
+            ${!window.VehicleFlags.insuranceValid(res[i].vehicle) ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID INS</p>' : ''}
           </div>
         </div>
       </div>`
@@ -280,9 +280,9 @@ function getPrevVehPage() {
           <div class="caption">
             <h4 class="color-white license-plate">#${escapeHtml(res[i].vehicle.plate)})</h4>
             <h5 class="color-white">${escapeHtml(res[i].vehicle.color)} ${escapeHtml(res[i].vehicle.model)}</h5>
-            ${(res[i].vehicle.isStolen === 'true' || res[i].vehicle.isStolen === '2') ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> STOLEN</p>' : ''}
-            ${(res[i].vehicle.validRegistration === 'false' || res[i].vehicle.validRegistration === '2') ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID REG</p>' : ''}
-            ${(res[i].vehicle.validInsurance === 'false' || res[i].vehicle.validInsurance === '2') ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID INS</p>' : ''}
+            ${window.VehicleFlags.stolen(res[i].vehicle) ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> STOLEN</p>' : ''}
+            ${!window.VehicleFlags.registrationValid(res[i].vehicle) ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID REG</p>' : ''}
+            ${!window.VehicleFlags.insuranceValid(res[i].vehicle) ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID INS</p>' : ''}
           </div>
         </div>
       </div>`
@@ -321,9 +321,9 @@ function getNextSearchVehPage() {
                       <h4 id="search-results-vehicles-thumbnail-plate-${res[i]._id}" class="color-white license-plate">#${escapeHtml(res[i].vehicle.plate)})</h4>
                       <h5 id="search-results-vehicles-thumbnail-color-model-${res[i]._id}" class="color-white">${escapeHtml(res[i].vehicle.color)} ${escapeHtml(res[i].vehicle.model)}</h5>
                       <h5 id="search-results-vehicles-thumbnail-owner-${res[i]._id}" class="color-white capitalize">${escapeHtml(res[i].vehicle.registeredOwner)}</h5>
-                      ${(res[i].vehicle.isStolen === 'true' || res[i].vehicle.isStolen === '2') ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> STOLEN</p>' : ''}
-                      ${(res[i].vehicle.validRegistration === 'false' || res[i].vehicle.validRegistration === '2') ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID REG</p>' : ''}
-                      ${(res[i].vehicle.validInsurance === 'false' || res[i].vehicle.validInsurance === '2') ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID INS</p>' : ''}
+                      ${window.VehicleFlags.stolen(res[i].vehicle) ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> STOLEN</p>' : ''}
+                      ${!window.VehicleFlags.registrationValid(res[i].vehicle) ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID REG</p>' : ''}
+                      ${!window.VehicleFlags.insuranceValid(res[i].vehicle) ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID INS</p>' : ''}
                     </div>
                   </div> 
                 </div>`
@@ -378,9 +378,9 @@ function getPrevSearchVehPage() {
                       <h4 id="search-results-vehicles-thumbnail-plate-${res[i]._id}" class="color-white license-plate">#${escapeHtml(res[i].vehicle.plate)})</h4>
                       <h5 id="search-results-vehicles-thumbnail-color-model-${res[i]._id}" class="color-white">${escapeHtml(res[i].vehicle.color)} ${escapeHtml(res[i].vehicle.model)}</h5>
                       <h5 id="search-results-vehicles-thumbnail-owner-${res[i]._id}" class="color-white capitalize">${escapeHtml(res[i].vehicle.registeredOwner)}</h5>
-                      ${(res[i].vehicle.isStolen === 'true' || res[i].vehicle.isStolen === '2') ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> STOLEN</p>' : ''}
-                      ${(res[i].vehicle.validRegistration === 'false' || res[i].vehicle.validRegistration === '2') ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID REG</p>' : ''}
-                      ${(res[i].vehicle.validInsurance === 'false' || res[i].vehicle.validInsurance === '2') ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID INS</p>' : ''}
+                      ${window.VehicleFlags.stolen(res[i].vehicle) ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> STOLEN</p>' : ''}
+                      ${!window.VehicleFlags.registrationValid(res[i].vehicle) ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID REG</p>' : ''}
+                      ${!window.VehicleFlags.insuranceValid(res[i].vehicle) ? '<p style="color:#ef4444; font-weight:bold; font-size:12px; margin:5px 0 0;"><i class="fa fa-exclamation-triangle"></i> INVALID INS</p>' : ''}
                     </div>
                   </div> 
                 </div>`

--- a/public/js/search-database.js
+++ b/public/js/search-database.js
@@ -421,7 +421,7 @@ $(document).ready(function () {
       owner = item.vehicle?.linkedCivilianID
         ? `Owner: ${ownerCache[item.vehicle.linkedCivilianID] || "Unknown"}`
         : "";
-      isStolen = item.vehicle?.isStolen === 'true' || item.vehicle?.isStolen === '2';
+      isStolen = window.VehicleFlags.stolen(item.vehicle);
       // Store the full vehicle info in recent searches for display purposes
       recentSearchQuery =
         item.vehicle?.make || item.vehicle?.plate || searchQuery;
@@ -720,14 +720,14 @@ $(document).ready(function () {
     $("#modelVeh").val(item.vehicle?.model || "");
     $("#colorView").val(item.vehicle?.color || "");
     // Convert to string "true"/"false" system for registration
-    const isValidRegistration = item.vehicle?.validRegistration === "1" || item.vehicle?.validRegistration === "true";
+    const isValidRegistration = window.VehicleFlags.registrationValid(item.vehicle);
     $("#validRegView").val(isValidRegistration ? "true" : "false");
     
     // Convert to string "true"/"false" system for insurance
-    const isValidInsurance = item.vehicle?.validInsurance === "1" || item.vehicle?.validInsurance === "true";
+    const isValidInsurance = window.VehicleFlags.insuranceValid(item.vehicle);
     $("#validInsView").val(isValidInsurance ? "true" : "false");
     // Convert to string "true"/"false" system
-    const isStolen = item.vehicle?.isStolen === "2" || item.vehicle?.isStolen === "true";
+    const isStolen = window.VehicleFlags.stolen(item.vehicle);
     $("#stolenView").val(isStolen ? "true" : "false");
     $("#vehicleID").val(item._id);
   }

--- a/public/js/vehicle-flags.js
+++ b/public/js/vehicle-flags.js
@@ -1,0 +1,99 @@
+/**
+ * Shared vehicle flag normalizers — window.VehicleFlags.
+ *
+ * Vehicle booleans are stored in two encodings. Newer records use the strings
+ * "true"/"false". Older records use a 1-based *select index* left over from the
+ * original form — which means the numeric encoding is NOT a boolean, and its
+ * polarity depends on the order the options appeared in that form:
+ *
+ *   Valid Registration?  <option>Yes</option><option>No</option>   -> "1" = valid
+ *   Valid Insurance?     <option>Yes</option><option>No</option>   -> "1" = valid
+ *   Marked Stolen?       <option value="false">No</option>
+ *                        <option value="true">Yes</option>         -> "2" = stolen
+ *
+ * So "1" means yes for registration/insurance and no for stolen. Every page
+ * used to carry its own toBool() and apply it to all four fields, which is
+ * exactly how the stolen flag ended up inverted — read each flag through its
+ * own named helper instead.
+ *
+ * As of Aug 2026 roughly 92% of the 2.25M vehicles still carry the numeric
+ * encoding, so these helpers are the common path, not a legacy edge case.
+ *
+ * Keep in sync with police-cad-app/utils/vehicleFlags.js.
+ */
+(function (window) {
+  'use strict';
+
+  /** "1"/1/true/"true" -> true. The polarity where option 1 means yes. */
+  function yesIsOne(val) {
+    return val === true || val === 1 || val === '1' || val === 'true';
+  }
+
+  /**
+   * Whether this record's flags were written by the department dashboard
+   * rather than the original form.
+   *
+   * The department dashboard (shipped Feb 2026) is the only writer that ever
+   * produced a numeric isExempt, and it always saves all four flags together —
+   * so a numeric isExempt marks the whole record as its work. That matters
+   * because it used the opposite polarity for isStolen: it wrote "1" for
+   * stolen where the original form wrote "2".
+   *
+   * ~3.1k records out of 2.25M. Once those are migrated this branch can go.
+   */
+  function isDeptDashboardRecord(veh) {
+    return !!veh && (veh.isExempt === '1' || veh.isExempt === '2');
+  }
+
+  var VehicleFlags = {
+    /** @param {object} veh inner vehicle object @returns {boolean} */
+    registrationValid: function (veh) {
+      return yesIsOne(veh && veh.validRegistration);
+    },
+
+    /** @param {object} veh inner vehicle object @returns {boolean} */
+    insuranceValid: function (veh) {
+      return yesIsOne(veh && veh.validInsurance);
+    },
+
+    /**
+     * Needs the whole vehicle, not just the flag: resolving the numeric
+     * encoding depends on which writer produced the record.
+     *
+     * @param {object} veh inner vehicle object @returns {boolean}
+     */
+    stolen: function (veh) {
+      var val = veh && veh.isStolen;
+      if (val === true || val === 'true') return true;
+      if (val === false || val === 'false') return false;
+      return isDeptDashboardRecord(veh) ? val === '1' : val === '2';
+    },
+
+    /**
+     * isExempt has no legacy form behind it — the only writer of its numeric
+     * values is the department dashboard, which wrote "1" for exempt.
+     *
+     * @param {object} veh inner vehicle object @returns {boolean}
+     */
+    exempt: function (veh) {
+      return yesIsOne(veh && veh.isExempt);
+    },
+
+    /**
+     * The encoding to write back. Everything written from here on is
+     * "true"/"false"; the numeric encoding is read-only legacy.
+     *
+     * @param {boolean} val @returns {"true"|"false"}
+     */
+    toApi: function (val) {
+      return val ? 'true' : 'false';
+    },
+  };
+
+  window.VehicleFlags = VehicleFlags;
+
+  // Also usable from the Playwright/unit harness.
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = VehicleFlags;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/test/vehicle-flags.test.js
+++ b/test/vehicle-flags.test.js
@@ -1,0 +1,116 @@
+var assert = require("assert");
+
+var Flags = require("../public/js/vehicle-flags");
+
+/*
+ * Cases are pinned to the real production distribution (2,248,869 vehicles,
+ * surveyed Aug 2026). The counts are in the test names so that anyone tempted
+ * to collapse this back into a single toBool() can see how much data each
+ * branch covers — and that the polarity genuinely differs per field.
+ *
+ * Mirrors police-cad-app/utils/__tests__/vehicleFlags.test.mjs.
+ */
+describe("vehicle-flags", function () {
+  describe("registrationValid", function () {
+    it('treats "1" as valid — the legacy select listed Yes first (2,068,404 docs)', function () {
+      assert.equal(Flags.registrationValid({ validRegistration: "1" }), true);
+    });
+    it('treats "2" as invalid (57,567 docs)', function () {
+      assert.equal(Flags.registrationValid({ validRegistration: "2" }), false);
+    });
+    it('treats "true"/"false" as themselves (120,976 / 1,922 docs)', function () {
+      assert.equal(Flags.registrationValid({ validRegistration: "true" }), true);
+      assert.equal(Flags.registrationValid({ validRegistration: "false" }), false);
+    });
+    it("is false for a missing field or a missing vehicle", function () {
+      assert.equal(Flags.registrationValid({}), false);
+      assert.equal(Flags.registrationValid(null), false);
+      assert.equal(Flags.registrationValid(undefined), false);
+    });
+  });
+
+  describe("insuranceValid", function () {
+    it("follows the same polarity as registration", function () {
+      assert.equal(Flags.insuranceValid({ validInsurance: "1" }), true); // 2,044,982
+      assert.equal(Flags.insuranceValid({ validInsurance: "2" }), false); //   80,992
+      assert.equal(Flags.insuranceValid({ validInsurance: "true" }), true); // 120,284
+      assert.equal(Flags.insuranceValid({}), false);
+    });
+  });
+
+  describe("stolen", function () {
+    it('treats "2" as stolen — the legacy select listed No first (95,592 docs)', function () {
+      assert.equal(Flags.stolen({ isStolen: "2" }), true);
+    });
+    it('treats "1" as NOT stolen (2,027,625 docs)', function () {
+      assert.equal(Flags.stolen({ isStolen: "1" }), false);
+    });
+    it("is the opposite polarity to registration, which is the whole bug", function () {
+      var v = { validRegistration: "1", isStolen: "1" };
+      assert.equal(Flags.registrationValid(v), true);
+      assert.equal(Flags.stolen(v), false);
+    });
+    it('treats "true"/"false"/"" as themselves (2,055 / 34,681 / 86,074 docs)', function () {
+      assert.equal(Flags.stolen({ isStolen: "true" }), true);
+      assert.equal(Flags.stolen({ isStolen: "false" }), false);
+      assert.equal(Flags.stolen({ isStolen: "" }), false);
+    });
+    it("is false for a missing field or a missing vehicle", function () {
+      assert.equal(Flags.stolen({}), false);
+      assert.equal(Flags.stolen(null), false);
+    });
+
+    describe("department-dashboard records, which used the inverted polarity", function () {
+      // That writer is the only source of a numeric isExempt, and it saved all
+      // four flags together — so a numeric isExempt identifies the record.
+      it('reads "1" as stolen there (111 docs)', function () {
+        assert.equal(Flags.stolen({ isStolen: "1", isExempt: "2" }), true);
+      });
+      it('reads "2" as NOT stolen there (2,731 docs)', function () {
+        assert.equal(Flags.stolen({ isStolen: "2", isExempt: "2" }), false);
+      });
+      it("still lets an explicit string win", function () {
+        assert.equal(Flags.stolen({ isStolen: "true", isExempt: "1" }), true);
+        assert.equal(Flags.stolen({ isStolen: "false", isExempt: "1" }), false);
+      });
+      it("does not trigger on a modern isExempt", function () {
+        assert.equal(Flags.stolen({ isStolen: "2", isExempt: "false" }), true);
+      });
+    });
+  });
+
+  describe("exempt", function () {
+    it('treats "1" as exempt — only the department dashboard wrote numerics (202 docs)', function () {
+      assert.equal(Flags.exempt({ isExempt: "1" }), true);
+      assert.equal(Flags.exempt({ isExempt: "2" }), false); // 2,926 docs
+      assert.equal(Flags.exempt({ isExempt: "true" }), true); // 2,437 docs
+      assert.equal(Flags.exempt({}), false); // 2,188,200 docs
+    });
+  });
+
+  describe("toApi", function () {
+    it("always writes the modern encoding", function () {
+      assert.equal(Flags.toApi(true), "true");
+      assert.equal(Flags.toApi(false), "false");
+    });
+  });
+
+  describe("the vehicle from the original bug report", function () {
+    // Plate 28TWQ102 / VIN BMDBY6CAVD7JMLUCA. All four values are exactly what
+    // one department-dashboard save produces, so they read with that polarity.
+    var reported = {
+      validRegistration: "1",
+      validInsurance: "1",
+      isStolen: "2",
+      isExempt: "2",
+    };
+    it("renders registration and insurance as valid", function () {
+      assert.equal(Flags.registrationValid(reported), true);
+      assert.equal(Flags.insuranceValid(reported), true);
+    });
+    it("renders it as not stolen and not exempt", function () {
+      assert.equal(Flags.stolen(reported), false);
+      assert.equal(Flags.exempt(reported), false);
+    });
+  });
+});

--- a/views/civ-dashboard.ejs
+++ b/views/civ-dashboard.ejs
@@ -2369,6 +2369,7 @@
   </script>
   <script src="/static/js/rank-progress.js"></script>
   <script>if (typeof loadMyRankProgress === 'function') loadMyRankProgress();</script>
+  <script src="/static/js/vehicle-flags.js"></script>
   <script src="/static/js/modern-dashboard.js"></script>
   <script src="/static/js/cloudinary-upload.js"></script>
 

--- a/views/command-dashboard.ejs
+++ b/views/command-dashboard.ejs
@@ -2537,6 +2537,7 @@
   <script src="/static/js/dd-settings.js"></script>
   <script src="/static/js/cd-beta-feedback.js"></script>
   <!-- Police command components -->
+  <script src="/static/js/vehicle-flags.js"></script>
   <script src="/static/js/cd-person-search.js"></script>
   <script src="/static/js/cd-vehicle-search.js"></script>
   <script src="/static/js/cd-firearm-search.js"></script>

--- a/views/community-details.ejs
+++ b/views/community-details.ejs
@@ -42,6 +42,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/js/bootstrap.min.js"></script>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/css/bootstrap.min.css" rel="stylesheet">
     <script src="/static/js/cloudinary-upload.js"></script>
+    <script src="/static/js/vehicle-flags.js"></script>
     <script src="/static/js/community-details.js"></script>
     <script src="/static/js/account-dropdown-admin.js"></script>
     <script>

--- a/views/department-dashboard.ejs
+++ b/views/department-dashboard.ejs
@@ -7466,6 +7466,7 @@ $('#dd-loading').hide();
   <!-- Shared utilities -->
   <script src="/static/js/dd-limits.js"></script>
   <!-- Civilian template component scripts -->
+  <script src="/static/js/vehicle-flags.js"></script>
   <script src="/static/js/dd-civilians.js"></script>
   <script src="/static/js/dd-vehicles.js"></script>
   <script src="/static/js/dd-firearms.js"></script>

--- a/views/dispatch-dashboard.ejs
+++ b/views/dispatch-dashboard.ejs
@@ -4637,6 +4637,7 @@
 <script src="/static/js/popper.js"></script>
 <script src="/static/js/main.js"></script>
 <script src="/static/js/name-database.js"></script>
+<script src="/static/js/vehicle-flags.js"></script>
 <script src="/static/js/plate-database.js"></script>
 <script src="/static/js/dispatch-dashboard.js"></script>
 <script src="/static/js/departments.js"></script>
@@ -6720,7 +6721,7 @@
             )
           }
           //check if vehicle is stolen and append result
-          if (res[i].vehicle.isStolen === "true" || res[i].vehicle.isStolen === "2") {
+          if (window.VehicleFlags.stolen(res[i].vehicle)) {
             $('#registered-cars-panel-body-'+index).append(
               `<div id="stolenMessage" class="alert alert-danger" style="display:block">`+
               `<strong>Danger!</strong> Vehicle reported as stolen.`+
@@ -6734,7 +6735,7 @@
             `Model: ${res[i].vehicle.model}<br/>`
           )
           //check for valid/invalid insurance and append result
-          const isValidInsurance = res[i].vehicle.validInsurance === "1" || res[i].vehicle.validInsurance === "true";
+          const isValidInsurance = window.VehicleFlags.insuranceValid(res[i].vehicle);
           if (isValidInsurance) {
             $('#registered-cars-panel-body-'+index).append(
               `<p class="plate-body-text">Insurance: <span style="color: #10b981;">true</span> <i class="ion-checkmark-circled color-green"></i></p>`
@@ -6745,7 +6746,7 @@
             )
           }
           //check for valid/invalid registration and append result
-          const isValidRegistration = res[i].vehicle.validRegistration === "1" || res[i].vehicle.validRegistration === "true";
+          const isValidRegistration = window.VehicleFlags.registrationValid(res[i].vehicle);
           if (isValidRegistration) {
             $('#registered-cars-panel-body-'+index).append(
               `<p class="plate-body-text">Registration: <span style="color: #10b981;">true</span> <i class="ion-checkmark-circled color-green"></i></p>`

--- a/views/police-dashboard.ejs
+++ b/views/police-dashboard.ejs
@@ -40,6 +40,7 @@
   <script src="/static/js/police-dashboard.js"></script>
   <script src="/static/js/department-backgrounds.js"></script>
   <script src="/static/js/name-database.js"></script>
+  <script src="/static/js/vehicle-flags.js"></script>
   <script src="/static/js/plate-database.js"></script>
   <script src="/static/js/bootstrap.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.0/jquery.cookie.min.js"></script>


### PR DESCRIPTION
## The bug

Reported in Discord: *"Every time that a cop searches someone's info on their vehicle it shows up as stolen or uninsured or unregistered even tho it's the complete opposite."*

Vehicle flags are stored in **two encodings**. Newer records use `"true"`/`"false"`. Older ones use a **1-based select index from the original form** — so the numeric encoding is *not* a boolean, and its polarity depends on that form's option order:

| field | old form markup | meaning |
|---|---|---|
| `validRegistration` / `validInsurance` | `<option>Yes</option><option>No</option>` | `"1"` = valid |
| `isStolen` | `<option value="false">No</option><option value="true">Yes</option>` | `"2"` = stolen |

**Five files carried their own `toBool()`** and applied it to all four flags — correct for registration and insurance, inverted for stolen.

Since `"1"` is 90% of vehicles and means *not* stolen, `cd-vehicle-search.js`, `cd-person-search.js` and `dd-vehicles.js` were painting a **Stolen badge on most of the community's cars**. Worse, `dd-vehicles.js` wrote that inverted value back via `boolToApi`, so a user "correcting" a false Stolen badge stored a value every other surface reads as genuinely stolen.

Separately, `community-details.js` accepted only `"true"`, so it reported 92% of vehicles as having invalid registration and insurance.

## Production data (2,248,869 vehicles)

| field | `"1"` | `"2"` | `"true"` | `"false"` |
|---|---|---|---|---|
| validRegistration | 2,068,404 | 57,567 | 120,976 | 1,922 |
| validInsurance | 2,044,982 | 80,992 | 120,284 | 2,611 |
| isStolen | 2,027,736 | 98,323 | 2,055 | 34,681 |

Polarity confirmed three ways: the old form's option order, the ratio match (`"1"`:`"2"` = 21:1 mirrors `"false"`:`"true"` = 17:1 for stolen), and the ~15 reader sites that already treat `"2"` as stolen.

## The fix

`public/js/vehicle-flags.js` replaces every local copy. It exposes a **named helper per field** — `registrationValid` / `insuranceValid` / `stolen` / `exempt` — specifically so the polarity can't be mixed up again by reaching for one generic truthiness test. Loaded ahead of every consumer in all six views (checked, since two files capture `window.VehicleFlags` at load time).

`dd-vehicles.js` also stops writing the numeric encoding.

### The department-dashboard exception

That dashboard wrote the numeric encoding with the *opposite* stolen polarity. Those records are identifiable — it's the only writer that ever produced a numeric `isExempt`, and it saves all four flags together — so exactly 3,128 records are special-cased.

Firearm reads are deliberately left alone: they only ever used `"true"`/`"false"` (99.98% of 1.37M).

## Relationship to the API change

[police-cad-api#179](https://github.com/Linesmerrill/police-cad-api/pull/179) normalizes flags on read and write, which fixes this for every client including the released mobile app. This PR is still worth landing as defense in depth — it covers a stale API deploy, and it stops the department dashboard writing bad data in the meantime.

## Verification

- 25 mocha tests pass, 18 new in `test/vehicle-flags.test.js` — polarity per field, the department-dashboard exception, and the exact vehicle from the bug report.
- `next lint` reports 0 errors; all 10 modified JS files parse.
- Swept for readers that understand only the numeric encoding — none remain on this surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
