### PR TITLE
feat(countdown): GTA 6 launch countdown on the landing page and /communities

### DIFF
--- a/app/api/countdown/route.ts
+++ b/app/api/countdown/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server';
+import { GTA6_FALLBACK, pickCountdown, type Countdown } from '@/lib/countdown';
+
+// Server-side proxy for the platform countdown.
+//
+// The Go API sits behind a bearer token and a gateway key, neither of which
+// should reach the browser, so the landing page asks this route instead. It is
+// also where the caching lives: countdowns change roughly never, and the
+// landing page is the busiest thing we serve.
+//
+// The ceiling on CACHE_TTL is the delay between correcting a slipped launch
+// date in Mongo and the site showing the new one.
+const CACHE_TTL = 5 * 60 * 1000;
+
+let cached: Countdown | null = null;
+let cachedAt = 0;
+let cacheValid = false;
+
+export async function GET() {
+  const now = Date.now();
+  if (cacheValid && now - cachedAt < CACHE_TTL) {
+    return NextResponse.json({ countdown: cached });
+  }
+
+  const base = process.env.POLICE_CAD_API_URL;
+  if (!base) {
+    return NextResponse.json({ countdown: GTA6_FALLBACK });
+  }
+
+  try {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (process.env.POLICE_CAD_API_TOKEN) {
+      headers['Authorization'] = process.env.POLICE_CAD_API_TOKEN;
+    }
+    if (process.env.POLICE_CAD_API_KEY) {
+      headers['X-API-Key'] = process.env.POLICE_CAD_API_KEY;
+    }
+
+    // Bounded so a slow API degrades the strip rather than the landing page.
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 4000);
+    let list: unknown;
+    try {
+      const res = await fetch(`${base.replace(/\/+$/, '')}/api/v1/countdowns?surface=web`, {
+        headers,
+        signal: controller.signal,
+        cache: 'no-store',
+      });
+      if (!res.ok) throw new Error(`countdowns ${res.status}`);
+      list = await res.json();
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    // A deliberately deactivated countdown is a real answer, so null gets
+    // cached too — otherwise every request would retry a healthy API.
+    cached = pickCountdown(list, 'gta6');
+    cachedAt = now;
+    cacheValid = true;
+    return NextResponse.json({ countdown: cached });
+  } catch {
+    // Do not cache the fallback: we want the next request to try the API again
+    // rather than sit on a stale date for five minutes after a blip.
+    return NextResponse.json({ countdown: GTA6_FALLBACK });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import Navbar from '@/components/Navbar';
 import Hero from '@/components/Hero';
+import Gta6Countdown from '@/components/Gta6Countdown';
 import Stats from '@/components/Stats';
 import WhatWeDo from '@/components/WhatWeDo';
 import Features from '@/components/Features';
@@ -25,6 +26,7 @@ export default function Home() {
     >
       <Navbar />
       <Hero />
+      <Gta6Countdown />
       <Stats />
       <WhatWeDo />
       <Features />

--- a/app/routes.js
+++ b/app/routes.js
@@ -94,6 +94,62 @@ function renderPendingDeletionIfApplicable(req, res, error) {
   return true;
 }
 
+// Platform launch countdown (GTA 6 and whatever comes after it).
+//
+// The date lives in Mongo so a slipped launch can be corrected without a
+// deploy anywhere. This is the EJS side; the Next.js landing page has its own
+// proxy at app/api/countdown/route.ts. The ticking itself is
+// public/js/countdown.js — the server only supplies the target.
+//
+// GTA6_COUNTDOWN_FALLBACK matches lib/countdown.ts and
+// police-cad-app/utils/countdown.js. Change one, change all three.
+var GTA6_COUNTDOWN_FALLBACK = {
+  slug: "gta6",
+  title: "Grand Theft Auto VI",
+  subtitle: "Back to Vice City.",
+  launchDate: "2026-11-19",
+  launchesAt: "2026-11-18T23:00:00Z",
+  mode: "localMidnight",
+  theme: "gta6",
+  postLaunchHours: 72,
+  active: true,
+};
+
+// The ceiling here is the delay between fixing a date in Mongo and the site
+// showing it. Without the cache every page load would add an API round-trip.
+var COUNTDOWN_CACHE_TTL_MS = 5 * 60 * 1000;
+var countdownCache = { value: null, at: 0, valid: false };
+
+// Resolves the countdown to render, never throwing and never blocking a page:
+// a failed lookup falls back to the constant above rather than taking the
+// page down with it.
+async function getActiveCountdown(surface) {
+  var now = Date.now();
+  if (countdownCache.valid && now - countdownCache.at < COUNTDOWN_CACHE_TTL_MS) {
+    return countdownCache.value;
+  }
+  if (!policeCadApiUrl) return GTA6_COUNTDOWN_FALLBACK;
+
+  try {
+    var response = await axios.get(
+      `${policeCadApiUrl}/api/v1/countdowns?surface=${encodeURIComponent(surface)}`,
+      Object.assign({}, config, { timeout: 4000 })
+    );
+    var list = Array.isArray(response.data) ? response.data : [];
+    // Only consider records that are still worth showing. A deliberately
+    // deactivated countdown is a real answer, so null gets cached too.
+    var active = list.filter(function (c) {
+      return c && c.active !== false && c.slug === "gta6";
+    });
+    countdownCache = { value: active[0] || null, at: now, valid: true };
+    return countdownCache.value;
+  } catch (err) {
+    // Deliberately not cached: the next request should retry rather than sit
+    // on a stale date for five minutes after a blip.
+    return GTA6_COUNTDOWN_FALLBACK;
+  }
+}
+
 module.exports = function (app, passport, server, nextApp, handle) {
   // Root route - use Next.js if available, otherwise fall back to EJS
   app.get("/", function (req, res) {
@@ -1408,13 +1464,14 @@ module.exports = function (app, passport, server, nextApp, handle) {
    *   Users can 'copy' the community code or 'edit' the community name.
    *   Also community admins can 'kick' members from their community.
    */
-  app.get("/communities", function (req, res) {
+  app.get("/communities", async function (req, res) {
     req.app.locals.specialContext = null;
     return res.render("communities", {
       members: null,
       communities: null,
       userID: null,
       user: req.user,
+      countdown: await getActiveCountdown("web"),
       referer: encodeURIComponent("/communities"),
       redirect: encodeURIComponent(redirect),
     });

--- a/components/Gta6Countdown.tsx
+++ b/components/Gta6Countdown.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { countdownState, type Countdown, type CountdownState } from '@/lib/countdown';
+
+// "Sunset Strip" — the strip is the horizon. Styling lives in
+// public/css/gta6-countdown.css, shared verbatim with the EJS pages so the two
+// surfaces cannot drift apart. Loaded over HTTP from /static (Express serves
+// public/ there) rather than imported, because the same file has to reach both.
+
+const DISMISS_KEY = 'gta6_countdown_dismissed_gta6';
+
+const pad = (n: number) => (n < 10 ? `0${n}` : String(n));
+
+// The zone is rendered on its own line, so the date line deliberately omits
+// it rather than repeating it.
+const formatLocal = (target: Date | null): string => {
+  if (!target) return '';
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    }).format(target);
+  } catch {
+    return target.toDateString();
+  }
+};
+
+const localZone = (target: Date): string => {
+  try {
+    const parts = new Intl.DateTimeFormat(undefined, {
+      timeZoneName: 'short',
+    }).formatToParts(target);
+    const zone = parts.find((p) => p.type === 'timeZoneName');
+    if (zone) return `your time · ${zone.value}`;
+  } catch {
+    /* fall through */
+  }
+  return 'your local time';
+};
+
+export default function Gta6Countdown() {
+  const [countdown, setCountdown] = useState<Countdown | null>(null);
+  const [state, setState] = useState<CountdownState | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+  const [entered, setEntered] = useState(false);
+  const [tickKey, setTickKey] = useState(0);
+
+  useEffect(() => {
+    try {
+      if (window.localStorage.getItem(DISMISS_KEY) === 'true') setDismissed(true);
+    } catch {
+      // Storage throws in some private modes. Showing the strip is the safe
+      // failure, not hiding it.
+    }
+  }, []);
+
+  useEffect(() => {
+    let alive = true;
+    fetch('/api/countdown')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((json) => {
+        if (alive && json?.countdown) setCountdown(json.countdown as Countdown);
+      })
+      .catch(() => {
+        // The strip is decoration; a failed lookup means no strip, not an error.
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!countdown) return;
+
+    const update = () => {
+      const next = countdownState(countdown);
+      setState(next);
+      // Retirement is the point of the hidden phase: without it a passed
+      // countdown becomes a negative timer.
+      if (next.phase === 'hidden') setCountdown(null);
+      setTickKey((k) => k + 1);
+    };
+
+    update();
+    setEntered(true);
+    const id = setInterval(update, 1000);
+
+    // Background tabs throttle intervals; resync on return.
+    const onVisible = () => {
+      if (!document.hidden) update();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      clearInterval(id);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
+  }, [countdown]);
+
+  const handleDismiss = () => {
+    try {
+      window.localStorage.setItem(DISMISS_KEY, 'true');
+    } catch {
+      /* dismissing for this pageview only is an acceptable degradation */
+    }
+    setDismissed(true);
+  };
+
+  if (dismissed || !countdown || !state || state.phase === 'hidden') return null;
+
+  const r = state.remaining;
+  const launched = state.phase === 'launched';
+
+  return (
+    <>
+      {/* eslint-disable-next-line @next/next/no-css-tags */}
+      <link rel="stylesheet" href="/static/css/gta6-countdown.css?v=2" />
+      <aside
+        className={`gta6-strip${entered ? ' gta6-strip--enter' : ''}`}
+        data-phase={state.phase}
+        aria-label={`${countdown.title} launch countdown`}
+      >
+        <span className="gta6-strip__sun" aria-hidden="true" />
+        <span className="gta6-strip__grain" aria-hidden="true" />
+
+        <div className="gta6-strip__inner">
+          <div className="gta6-strip__lede">
+            <p className="gta6-strip__eyebrow">Countdown</p>
+            <h2 className="gta6-strip__title">{countdown.title}</h2>
+            {countdown.subtitle ? (
+              <p className="gta6-strip__subtitle">{countdown.subtitle}</p>
+            ) : null}
+          </div>
+
+          {!launched && r ? (
+            <ol className="gta6-clock" aria-hidden="true">
+              <li className="gta6-unit">
+                <span className="gta6-unit__value">{r.days}</span>
+                <span className="gta6-unit__label">Days</span>
+              </li>
+              <li className="gta6-sep">:</li>
+              <li className="gta6-unit">
+                <span className="gta6-unit__value">{pad(r.hours)}</span>
+                <span className="gta6-unit__label">Hrs</span>
+              </li>
+              <li className="gta6-sep">:</li>
+              <li className="gta6-unit">
+                <span className="gta6-unit__value">{pad(r.minutes)}</span>
+                <span className="gta6-unit__label">Min</span>
+              </li>
+              <li className="gta6-sep">:</li>
+              {/* Keyed so the heartbeat animation replays each second. Only the
+                  seconds column — a pulse on every unit would read as jitter. */}
+              <li className="gta6-unit gta6-unit--tick" key={tickKey}>
+                <span className="gta6-unit__value">{pad(r.seconds)}</span>
+                <span className="gta6-unit__label">Sec</span>
+              </li>
+            </ol>
+          ) : null}
+
+          {launched ? <p className="gta6-strip__out">Out now</p> : null}
+
+          <div className="gta6-strip__meta">
+            <p className="gta6-strip__local">
+              {formatLocal(state.target)}
+              <span className="gta6-strip__zone">
+                {state.target ? localZone(state.target) : ''}
+              </span>
+            </p>
+            {countdown.ctaUrl && countdown.ctaLabel ? (
+              <a
+                className="gta6-strip__cta"
+                href={countdown.ctaUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {countdown.ctaLabel}
+              </a>
+            ) : null}
+          </div>
+
+          {/* Announced once a minute rather than every second, which would be
+              unusable read aloud. */}
+          <p className="gta6-sr-only" role="status">
+            {launched
+              ? 'Out now.'
+              : r
+                ? `${r.days} days, ${r.hours} hours and ${r.minutes} minutes until launch.`
+                : ''}
+          </p>
+        </div>
+
+        <button
+          type="button"
+          className="gta6-strip__dismiss"
+          onClick={handleDismiss}
+          aria-label={`Hide the ${countdown.title} countdown`}
+        >
+          &times;
+        </button>
+
+        <span className="gta6-strip__horizon" aria-hidden="true" />
+      </aside>
+    </>
+  );
+}

--- a/lib/countdown.ts
+++ b/lib/countdown.ts
@@ -1,0 +1,162 @@
+// Countdown target resolution for the Next.js side of the site.
+//
+// The same rules exist in two other places, because the three runtimes cannot
+// share a module: `public/js/countdown.js` for the EJS pages (a standalone
+// browser script, no build step) and `police-cad-app/utils/countdown.js` for
+// the mobile app. Change one, change all three. The mobile copy carries the
+// unit tests.
+
+export const COUNTDOWN_MODE_LOCAL_MIDNIGHT = "localMidnight";
+export const COUNTDOWN_MODE_INSTANT = "instant";
+
+export const DEFAULT_POST_LAUNCH_HOURS = 72;
+
+export type CountdownPhase = "counting" | "launched" | "hidden";
+
+export interface Countdown {
+  slug: string;
+  title: string;
+  subtitle?: string;
+  launchDate?: string;
+  launchesAt?: string;
+  mode?: string;
+  theme?: string;
+  postLaunchHours?: number;
+  ctaLabel?: string;
+  ctaUrl?: string;
+  active?: boolean;
+}
+
+export interface Remaining {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+}
+
+export interface CountdownState {
+  phase: CountdownPhase;
+  target: Date | null;
+  remaining: Remaining | null;
+}
+
+// Baked-in fallback so the strip renders even if the API is unreachable or
+// predates the countdowns endpoint. Whatever the API returns wins.
+export const GTA6_FALLBACK: Countdown = {
+  slug: "gta6",
+  title: "Grand Theft Auto VI",
+  subtitle: "Back to Vice City.",
+  launchDate: "2026-11-19",
+  launchesAt: "2026-11-18T23:00:00Z",
+  mode: COUNTDOWN_MODE_LOCAL_MIDNIGHT,
+  theme: "gta6",
+  postLaunchHours: DEFAULT_POST_LAUNCH_HOURS,
+  active: true,
+};
+
+const DATE_ONLY = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+// Resolves the instant a countdown is aiming at.
+//
+// `localMidnight` returns midnight on launchDate in the visitor's own timezone.
+// That is deliberate: console storefronts list GTA 6 at local midnight in every
+// market rather than one synchronized worldwide moment, so a single UTC instant
+// converted to local time would read zero well after a New Zealand player could
+// already play, and well before a Los Angeles player could.
+//
+// Returns null when the record cannot produce a target, so callers render
+// nothing instead of counting down to NaN.
+export const resolveTarget = (countdown: Countdown | null | undefined): Date | null => {
+  if (!countdown) return null;
+
+  if (countdown.mode === COUNTDOWN_MODE_INSTANT) {
+    if (!countdown.launchesAt) return null;
+    const at = new Date(countdown.launchesAt);
+    return Number.isNaN(at.getTime()) ? null : at;
+  }
+
+  const match = DATE_ONLY.exec(String(countdown.launchDate || ""));
+  if (!match) return null;
+
+  const [, year, month, day] = match;
+  // Month is 0-indexed. This constructor reads as local time, which is the
+  // point — the same call yields a different instant per timezone.
+  const target = new Date(Number(year), Number(month) - 1, Number(day), 0, 0, 0, 0);
+  return Number.isNaN(target.getTime()) ? null : target;
+};
+
+const postLaunchMs = (countdown: Countdown): number => {
+  const hours = Number(countdown?.postLaunchHours);
+  return (Number.isFinite(hours) && hours > 0 ? hours : DEFAULT_POST_LAUNCH_HOURS) * 3600000;
+};
+
+export const splitRemaining = (ms: number): Remaining => {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  return {
+    days: Math.floor(total / 86400),
+    hours: Math.floor((total % 86400) / 3600),
+    minutes: Math.floor((total % 3600) / 60),
+    seconds: total % 60,
+  };
+};
+
+// The single call the component makes each tick.
+//
+// Retirement is part of this on purpose: without it a countdown that has passed
+// becomes a negative timer, or dead UI nobody remembers to take down.
+export const countdownState = (
+  countdown: Countdown | null | undefined,
+  now: Date = new Date()
+): CountdownState => {
+  const hidden: CountdownState = { phase: "hidden", target: null, remaining: null };
+
+  if (!countdown || countdown.active === false) return hidden;
+
+  const target = resolveTarget(countdown);
+  if (!target) return hidden;
+
+  const delta = target.getTime() - now.getTime();
+  if (delta > 0) {
+    return { phase: "counting", target, remaining: splitRemaining(delta) };
+  }
+  if (-delta < postLaunchMs(countdown)) {
+    return { phase: "launched", target, remaining: null };
+  }
+  return hidden;
+};
+
+// "Thu, Nov 19, 12:00 AM EST" — the visitor's own local time.
+export const formatLocalTarget = (target: Date | null): string => {
+  if (!target) return "";
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      timeZoneName: "short",
+    }).format(target);
+  } catch {
+    return target.toDateString();
+  }
+};
+
+// Picks the countdown to feature from an API response: the soonest one that is
+// still worth showing.
+export const pickCountdown = (
+  list: unknown,
+  slug?: string,
+  now: Date = new Date()
+): Countdown | null => {
+  if (!Array.isArray(list)) return null;
+  const candidates = (list as Countdown[]).filter(
+    (c) => c && (!slug || c.slug === slug) && countdownState(c, now).phase !== "hidden"
+  );
+  if (candidates.length === 0) return null;
+  return candidates.sort((a, b) => {
+    const at = resolveTarget(a);
+    const bt = resolveTarget(b);
+    return (at ? at.getTime() : Infinity) - (bt ? bt.getTime() : Infinity);
+  })[0];
+};

--- a/public/css/gta6-countdown.css
+++ b/public/css/gta6-countdown.css
@@ -1,0 +1,447 @@
+/* ==========================================================================
+   Launch countdown — "Sunset Strip"
+   --------------------------------------------------------------------------
+   Shared by the Next.js landing page (components/Gta6Countdown.tsx) and the
+   EJS pages (views/partials/gta6-countdown.ejs + public/js/countdown.js).
+   Both load it over HTTP from /static/css/gta6-countdown.css, so the markup
+   and class names must stay identical on both surfaces.
+
+   The idea: the strip is the horizon. A hairline gradient rule runs its full
+   width with a slatted sun bleeding up from behind it, and the numerals sit on
+   top like a skyline. The field stays near-black — all the colour is light.
+   Evokes a Miami dusk without borrowing anyone's artwork.
+   ========================================================================== */
+
+@import url("https://fonts.googleapis.com/css2?family=Archivo:wght@500;600;700&family=Archivo+Black&display=swap");
+
+.gta6-strip {
+  --gta-magenta: #ff2d8e;
+  --gta-rose: #ff5c7a;
+  --gta-orange: #ff7a2f;
+  --gta-amber: #ffb03a;
+  --gta-gold: #ffd86b;
+  --gta-night: #0b0410;
+  --gta-ink: #07030b;
+  --gta-bone: #fff3e6;
+  --gta-sweep: linear-gradient(
+    90deg,
+    var(--gta-magenta),
+    var(--gta-rose),
+    var(--gta-orange),
+    var(--gta-amber),
+    var(--gta-gold)
+  );
+
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 1.15rem clamp(1rem, 4vw, 2.5rem) 1.35rem;
+  background:
+    radial-gradient(120% 180% at 18% 130%, rgba(255, 45, 142, 0.16), transparent 62%),
+    linear-gradient(180deg, var(--gta-ink), var(--gta-night));
+  border-top: 1px solid rgba(255, 122, 47, 0.12);
+  font-family: "Archivo", ui-sans-serif, system-ui, sans-serif;
+  color: var(--gta-bone);
+}
+
+/* Rounded variant for the /communities promo slot, which sits inside a
+   padded container rather than spanning the viewport. */
+.gta6-strip--inset {
+  border-radius: 14px;
+  border: 1px solid rgba(255, 122, 47, 0.16);
+}
+
+.gta6-strip[hidden] {
+  display: none !important;
+}
+
+/* --- the sun ------------------------------------------------------------ */
+/* Sits low and off-centre so the strip's bottom edge cuts it in half. The
+   slats are the giveaway motif of a retro sunset; they do more work here than
+   any amount of gradient would. */
+.gta6-strip__sun {
+  position: absolute;
+  z-index: -2;
+  left: clamp(-3.5rem, 2vw, 1.5rem);
+  bottom: -5.5rem;
+  width: 11rem;
+  height: 11rem;
+  pointer-events: none;
+  /* Deliberately faint. At full strength the slats read as a sticker pasted
+     over the copy; at this weight they read as light behind it. */
+  opacity: 0.34;
+  filter: blur(2.5px);
+  animation: gta6-breathe 7s ease-in-out infinite;
+}
+
+.gta6-strip__sun::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at 50% 50%,
+    var(--gta-gold) 0%,
+    var(--gta-amber) 32%,
+    var(--gta-orange) 55%,
+    var(--gta-magenta) 76%,
+    rgba(255, 45, 142, 0) 79%
+  );
+  filter: blur(1px);
+}
+
+/* Venetian slats, thickening toward the bottom the way the real motif does.
+   The mask fades the disc out at its edges so it reads as light rather than a
+   sticker pasted on the background. */
+.gta6-strip__sun::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    to bottom,
+    transparent 0 9px,
+    var(--gta-ink) 9px 11px,
+    transparent 11px 20px,
+    var(--gta-ink) 20px 23px,
+    transparent 23px 32px,
+    var(--gta-ink) 32px 37px
+  );
+  background-position: 0 55%;
+  -webkit-mask-image: radial-gradient(circle at 50% 50%, #000 62%, transparent 79%);
+  mask-image: radial-gradient(circle at 50% 50%, #000 62%, transparent 79%);
+}
+
+/* --- grain -------------------------------------------------------------- */
+/* Just enough tooth that the gradients do not look like flat vector fills. */
+.gta6-strip__grain {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  opacity: 0.05;
+  mix-blend-mode: overlay;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3'/%3E%3C/filter%3E%3Crect width='140' height='140' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+/* --- the horizon -------------------------------------------------------- */
+/* Warm haze rising off the rule. This is what makes the strip read as a
+   horizon at dusk rather than a black bar with a coloured border. */
+.gta6-strip::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 55%;
+  z-index: -1;
+  pointer-events: none;
+  background: linear-gradient(
+    to top,
+    rgba(255, 122, 47, 0.16),
+    rgba(255, 45, 142, 0.07) 45%,
+    transparent 100%
+  );
+}
+
+.gta6-strip__horizon {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 1.5px;
+  background: var(--gta-sweep);
+  background-size: 220% 100%;
+  animation: gta6-drift 16s linear infinite;
+  /* Three stacked blooms: a tight hot core, a mid falloff, and a wide wash.
+     One shadow reads as a glowing border; three read as a light source. */
+  box-shadow:
+    0 0 4px rgba(255, 216, 107, 0.75),
+    0 0 14px rgba(255, 122, 47, 0.6),
+    0 0 40px rgba(255, 45, 142, 0.35);
+}
+
+/* --- layout ------------------------------------------------------------- */
+.gta6-strip__inner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: clamp(0.9rem, 3vw, 2.25rem);
+  max-width: 1180px;
+  margin: 0 auto;
+  padding-right: 2rem; /* room for the dismiss control */
+}
+
+.gta6-strip__lede {
+  min-width: 0;
+}
+
+.gta6-strip__eyebrow {
+  margin: 0 0 0.2rem;
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.34em;
+  text-transform: uppercase;
+  color: var(--gta-amber);
+}
+
+.gta6-strip__title {
+  margin: 0;
+  font-size: clamp(0.95rem, 1.5vw, 1.1rem);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--gta-bone);
+  white-space: nowrap;
+}
+
+.gta6-strip__subtitle {
+  margin: 0.15rem 0 0;
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: rgba(255, 243, 230, 0.52);
+}
+
+/* --- the clock ---------------------------------------------------------- */
+.gta6-clock {
+  display: flex;
+  align-items: flex-start;
+  gap: clamp(0.35rem, 1vw, 0.8rem);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  /* drop-shadow rather than text-shadow: the numerals are gradient-clipped
+     text, which cannot take a text-shadow. */
+  filter: drop-shadow(0 0 16px rgba(255, 45, 142, 0.34));
+}
+
+.gta6-unit {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 2.4ch;
+}
+
+.gta6-unit__value {
+  font-family: "Archivo Black", "Archivo", ui-sans-serif, system-ui, sans-serif;
+  font-size: clamp(1.6rem, 3.4vw, 2.3rem);
+  line-height: 1;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1;
+  background: var(--gta-sweep);
+  background-size: 340% 100%;
+  background-position: var(--gta-unit-pos, 0%) 0;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  /* Browsers without background-clip:text still get readable numerals. */
+  -webkit-text-fill-color: transparent;
+}
+
+/* Each unit samples a different slice of the sweep, so the row reads
+   magenta on the left through gold on the right rather than four
+   identical gradients. */
+.gta6-unit:nth-child(1) .gta6-unit__value { --gta-unit-pos: 0%; }
+.gta6-unit:nth-child(3) .gta6-unit__value { --gta-unit-pos: 33%; }
+.gta6-unit:nth-child(5) .gta6-unit__value { --gta-unit-pos: 66%; }
+.gta6-unit:nth-child(7) .gta6-unit__value { --gta-unit-pos: 100%; }
+
+.gta6-unit__label {
+  margin-top: 0.35rem;
+  font-size: 0.54rem;
+  font-weight: 600;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(255, 243, 230, 0.4);
+}
+
+.gta6-sep {
+  align-self: flex-start;
+  margin-top: 0.05em;
+  font-family: "Archivo Black", "Archivo", sans-serif;
+  font-size: clamp(1.2rem, 2.6vw, 1.7rem);
+  line-height: 1;
+  color: rgba(255, 122, 47, 0.34);
+}
+
+/* The seconds column gets a heartbeat on each tick. Only the seconds — a pulse
+   on every unit would read as jitter. */
+.gta6-unit--tick .gta6-unit__value {
+  animation: gta6-tick 420ms ease-out;
+}
+
+/* --- local time + CTA --------------------------------------------------- */
+.gta6-strip__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-left: auto;
+  text-align: right;
+}
+
+.gta6-strip__local {
+  margin: 0;
+  font-size: 0.74rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: rgba(255, 243, 230, 0.62);
+  font-variant-numeric: tabular-nums;
+}
+
+.gta6-strip__zone {
+  display: block;
+  margin-top: 0.15rem;
+  font-size: 0.58rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255, 176, 58, 0.62);
+}
+
+.gta6-strip__cta {
+  align-self: flex-end;
+  display: inline-block;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 122, 47, 0.4);
+  background: rgba(255, 45, 142, 0.1);
+  color: var(--gta-gold);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.gta6-strip__cta:hover,
+.gta6-strip__cta:focus-visible {
+  background: rgba(255, 45, 142, 0.2);
+  border-color: rgba(255, 216, 107, 0.7);
+  transform: translateY(-1px);
+}
+
+/* --- launched state ----------------------------------------------------- */
+.gta6-strip__out {
+  display: none;
+  margin: 0;
+  font-family: "Archivo Black", "Archivo", sans-serif;
+  font-size: clamp(1.5rem, 3.2vw, 2.1rem);
+  line-height: 1;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  background: var(--gta-sweep);
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  filter: drop-shadow(0 0 20px rgba(255, 45, 142, 0.45));
+  animation: gta6-drift 6s linear infinite;
+}
+
+.gta6-strip[data-phase="launched"] .gta6-clock { display: none; }
+.gta6-strip[data-phase="launched"] .gta6-strip__out { display: block; }
+
+/* --- dismiss ------------------------------------------------------------ */
+.gta6-strip__dismiss {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.6rem;
+  width: 1.7rem;
+  height: 1.7rem;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: rgba(255, 243, 230, 0.32);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 0.2s ease, background 0.2s ease;
+}
+
+.gta6-strip__dismiss:hover,
+.gta6-strip__dismiss:focus-visible {
+  color: var(--gta-gold);
+  background: rgba(255, 122, 47, 0.14);
+}
+
+/* Screen readers get a summary that updates once a minute instead of the
+   per-second digits, which would be unusable read aloud. */
+.gta6-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* --- motion ------------------------------------------------------------- */
+@keyframes gta6-drift {
+  from { background-position: 0% 0; }
+  to { background-position: 200% 0; }
+}
+
+@keyframes gta6-breathe {
+  0%, 100% { opacity: 0.28; transform: scale(1); }
+  50% { opacity: 0.4; transform: scale(1.035); }
+}
+
+@keyframes gta6-tick {
+  0% { transform: translateY(0.06em) scale(0.97); opacity: 0.6; }
+  60% { transform: translateY(0) scale(1.03); opacity: 1; }
+  100% { transform: translateY(0) scale(1); opacity: 1; }
+}
+
+@keyframes gta6-rise {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.gta6-strip--enter {
+  animation: gta6-rise 600ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+/* --- responsive --------------------------------------------------------- */
+@media (max-width: 860px) {
+  .gta6-strip__inner {
+    gap: 0.75rem 1.1rem;
+  }
+  .gta6-strip__meta {
+    margin-left: 0;
+    width: 100%;
+    text-align: left;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+  .gta6-strip__cta { align-self: center; }
+  .gta6-strip__title { white-space: normal; }
+}
+
+@media (max-width: 560px) {
+  .gta6-strip { padding-bottom: 1.15rem; }
+  .gta6-strip__sun { width: 10rem; height: 10rem; bottom: -3rem; }
+  .gta6-strip__subtitle { display: none; }
+  .gta6-unit { min-width: 2.1ch; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gta6-strip__horizon,
+  .gta6-strip__sun,
+  .gta6-strip__out,
+  .gta6-strip--enter,
+  .gta6-unit--tick .gta6-unit__value {
+    animation: none;
+  }
+}

--- a/public/js/countdown.js
+++ b/public/js/countdown.js
@@ -1,0 +1,208 @@
+/* Launch countdown ticker for the EJS pages.
+ *
+ * The server renders the target onto the element as data- attributes (see
+ * views/partials/gta6-countdown.ejs); this file resolves it, ticks, and
+ * retires the strip once the launch is far enough past.
+ *
+ * The same rules exist in lib/countdown.ts (Next.js landing page) and
+ * police-cad-app/utils/countdown.js (mobile). The three runtimes cannot share
+ * a module — this one is a plain browser script with no build step. Change
+ * one, change all three; the mobile copy carries the unit tests.
+ */
+(function () {
+  "use strict";
+
+  var DEFAULT_POST_LAUNCH_HOURS = 72;
+  var DATE_ONLY = /^(\d{4})-(\d{2})-(\d{2})$/;
+  var DISMISS_PREFIX = "gta6_countdown_dismissed_";
+
+  // Resolves the instant a countdown is aiming at.
+  //
+  // "localMidnight" returns midnight on launchDate in the visitor's own
+  // timezone. Deliberate: console storefronts list GTA 6 at local midnight in
+  // every market rather than one synchronized worldwide moment, so converting
+  // a single UTC instant would read zero long after a New Zealand player could
+  // play and long before a Los Angeles player could.
+  function resolveTarget(cfg) {
+    if (cfg.mode === "instant") {
+      if (!cfg.launchesAt) return null;
+      var at = new Date(cfg.launchesAt);
+      return isNaN(at.getTime()) ? null : at;
+    }
+    var match = DATE_ONLY.exec(String(cfg.launchDate || ""));
+    if (!match) return null;
+    // Month is 0-indexed. This constructor reads as local time, which is the
+    // point — the same call yields a different instant per timezone.
+    var target = new Date(+match[1], +match[2] - 1, +match[3], 0, 0, 0, 0);
+    return isNaN(target.getTime()) ? null : target;
+  }
+
+  function pad(n) {
+    return n < 10 ? "0" + n : String(n);
+  }
+
+  function formatLocal(target) {
+    try {
+      return new Intl.DateTimeFormat(undefined, {
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      }).format(target);
+    } catch (e) {
+      return target.toDateString();
+    }
+  }
+
+  function localZone(target) {
+    try {
+      var parts = new Intl.DateTimeFormat(undefined, {
+        timeZoneName: "short",
+      }).formatToParts(target);
+      for (var i = 0; i < parts.length; i++) {
+        if (parts[i].type === "timeZoneName") return "your time · " + parts[i].value;
+      }
+    } catch (e) {
+      /* fall through */
+    }
+    return "your local time";
+  }
+
+  function init(root) {
+    if (root.__gta6Bound) return;
+    root.__gta6Bound = true;
+
+    var slug = root.getAttribute("data-slug") || "countdown";
+    var storageKey = DISMISS_PREFIX + slug;
+
+    try {
+      if (window.localStorage && localStorage.getItem(storageKey) === "true") {
+        root.remove();
+        return;
+      }
+    } catch (e) {
+      // Storage can throw in private modes. Showing the strip is the safe
+      // failure here, not hiding it.
+    }
+
+    var cfg = {
+      mode: root.getAttribute("data-mode") || "localMidnight",
+      launchDate: root.getAttribute("data-launch-date") || "",
+      launchesAt: root.getAttribute("data-launches-at") || "",
+    };
+    var hours = parseInt(root.getAttribute("data-post-launch-hours"), 10);
+    var postLaunchMs = (hours > 0 ? hours : DEFAULT_POST_LAUNCH_HOURS) * 3600000;
+
+    var target = resolveTarget(cfg);
+    if (!target) {
+      // A record that cannot produce a target renders nothing rather than
+      // counting down to NaN.
+      root.remove();
+      return;
+    }
+
+    var els = {
+      days: root.querySelector("[data-gta6-days]"),
+      hours: root.querySelector("[data-gta6-hours]"),
+      minutes: root.querySelector("[data-gta6-minutes]"),
+      seconds: root.querySelector("[data-gta6-seconds]"),
+      secondsUnit: root.querySelector("[data-gta6-seconds-unit]"),
+      local: root.querySelector("[data-gta6-local]"),
+      zone: root.querySelector("[data-gta6-zone]"),
+      sr: root.querySelector("[data-gta6-sr]"),
+    };
+
+    if (els.local) els.local.textContent = formatLocal(target);
+    if (els.zone) els.zone.textContent = localZone(target);
+
+    var dismiss = root.querySelector("[data-gta6-dismiss]");
+    if (dismiss) {
+      dismiss.addEventListener("click", function () {
+        try {
+          if (window.localStorage) localStorage.setItem(storageKey, "true");
+        } catch (e) {
+          /* dismissing for this pageview only is an acceptable degradation */
+        }
+        root.remove();
+      });
+    }
+
+    var timer = null;
+    var lastSecond = -1;
+    var lastAnnouncedMinute = -1;
+
+    function stop() {
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+    }
+
+    function tick() {
+      var delta = target.getTime() - Date.now();
+
+      if (delta <= 0) {
+        // Retirement matters: without it a passed countdown becomes a
+        // negative timer, or dead UI nobody remembers to take down.
+        if (-delta >= postLaunchMs) {
+          stop();
+          root.remove();
+          return;
+        }
+        if (root.getAttribute("data-phase") !== "launched") {
+          root.setAttribute("data-phase", "launched");
+          if (els.sr) els.sr.textContent = "Out now.";
+        }
+        return;
+      }
+
+      var total = Math.floor(delta / 1000);
+      var d = Math.floor(total / 86400);
+      var h = Math.floor((total % 86400) / 3600);
+      var m = Math.floor((total % 3600) / 60);
+      var s = total % 60;
+
+      if (els.days) els.days.textContent = String(d);
+      if (els.hours) els.hours.textContent = pad(h);
+      if (els.minutes) els.minutes.textContent = pad(m);
+      if (els.seconds) els.seconds.textContent = pad(s);
+
+      // Retrigger the heartbeat on the seconds column only.
+      if (s !== lastSecond && els.secondsUnit) {
+        els.secondsUnit.classList.remove("gta6-unit--tick");
+        void els.secondsUnit.offsetWidth; // force reflow so the animation replays
+        els.secondsUnit.classList.add("gta6-unit--tick");
+        lastSecond = s;
+      }
+
+      // Announce at most once a minute — per-second updates are unusable read
+      // aloud.
+      if (els.sr && m !== lastAnnouncedMinute) {
+        lastAnnouncedMinute = m;
+        els.sr.textContent = d + " days, " + h + " hours and " + m + " minutes until launch.";
+      }
+    }
+
+    tick();
+    root.hidden = false;
+    root.classList.add("gta6-strip--enter");
+    timer = setInterval(tick, 1000);
+
+    // Long-idle tabs drift; resync on return rather than trusting the interval.
+    document.addEventListener("visibilitychange", function () {
+      if (!document.hidden) tick();
+    });
+  }
+
+  function initAll() {
+    var nodes = document.querySelectorAll("[data-gta6-countdown]");
+    for (var i = 0; i < nodes.length; i++) init(nodes[i]);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initAll);
+  } else {
+    initAll();
+  }
+})();

--- a/views/communities.ejs
+++ b/views/communities.ejs
@@ -365,6 +365,12 @@
         <% } %>
       </div>
     </nav>
+    <!-- Launch countdown. Sits above the promo bar so the hype element reads
+         first on a page people arrive at in discovery mode. Renders nothing
+         unless the route supplied an active countdown. -->
+    <div class="mx-3 mt-3">
+      <% include partials/gta6-countdown %>
+    </div>
     <!-- Promo Bar - Compact version with home page styling -->
     <div id="promo-bar" class="mx-3 mt-3 rounded-xl relative" style="display: flex; align-items: center; justify-content: space-between; background: rgba(255, 255, 255, 0.05); backdrop-filter: blur(10px); border: 1px solid rgba(59, 130, 246, 0.2); color: #fff; box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2); padding: 0.75rem 2.5rem 0.75rem 1rem;">
       <div style="display: flex; align-items: center; gap: 0.75rem;">

--- a/views/partials/gta6-countdown.ejs
+++ b/views/partials/gta6-countdown.ejs
@@ -1,0 +1,76 @@
+<%
+  /* Launch countdown strip. Rendered only when the route supplied a countdown
+     (see getActiveCountdown in app/routes.js). The server hands over the
+     target; public/js/countdown.js does the ticking and the retirement.
+
+     Styling is shared with the Next.js landing page via
+     /static/css/gta6-countdown.css — keep the class names in sync. */
+%>
+<% if (typeof countdown !== "undefined" && countdown) { %>
+<link rel="stylesheet" href="/static/css/gta6-countdown.css?v=2" />
+<aside
+  class="gta6-strip gta6-strip--inset"
+  data-gta6-countdown
+  data-slug="<%= countdown.slug %>"
+  data-mode="<%= countdown.mode || 'localMidnight' %>"
+  data-launch-date="<%= countdown.launchDate || '' %>"
+  data-launches-at="<%= countdown.launchesAt || '' %>"
+  data-post-launch-hours="<%= countdown.postLaunchHours || 72 %>"
+  aria-label="<%= countdown.title %> launch countdown"
+  hidden
+>
+  <span class="gta6-strip__sun" aria-hidden="true"></span>
+  <span class="gta6-strip__grain" aria-hidden="true"></span>
+
+  <div class="gta6-strip__inner">
+    <div class="gta6-strip__lede">
+      <p class="gta6-strip__eyebrow">Countdown</p>
+      <h2 class="gta6-strip__title"><%= countdown.title %></h2>
+      <% if (countdown.subtitle) { %>
+        <p class="gta6-strip__subtitle"><%= countdown.subtitle %></p>
+      <% } %>
+    </div>
+
+    <ol class="gta6-clock" aria-hidden="true">
+      <li class="gta6-unit">
+        <span class="gta6-unit__value" data-gta6-days>--</span>
+        <span class="gta6-unit__label">Days</span>
+      </li>
+      <li class="gta6-sep" aria-hidden="true">:</li>
+      <li class="gta6-unit">
+        <span class="gta6-unit__value" data-gta6-hours>--</span>
+        <span class="gta6-unit__label">Hrs</span>
+      </li>
+      <li class="gta6-sep" aria-hidden="true">:</li>
+      <li class="gta6-unit">
+        <span class="gta6-unit__value" data-gta6-minutes>--</span>
+        <span class="gta6-unit__label">Min</span>
+      </li>
+      <li class="gta6-sep" aria-hidden="true">:</li>
+      <li class="gta6-unit" data-gta6-seconds-unit>
+        <span class="gta6-unit__value" data-gta6-seconds>--</span>
+        <span class="gta6-unit__label">Sec</span>
+      </li>
+    </ol>
+
+    <p class="gta6-strip__out">Out now</p>
+
+    <div class="gta6-strip__meta">
+      <p class="gta6-strip__local">
+        <span data-gta6-local></span>
+        <span class="gta6-strip__zone" data-gta6-zone></span>
+      </p>
+      <% if (countdown.ctaUrl && countdown.ctaLabel) { %>
+        <a class="gta6-strip__cta" href="<%= countdown.ctaUrl %>" rel="noopener noreferrer" target="_blank"><%= countdown.ctaLabel %></a>
+      <% } %>
+    </div>
+
+    <p class="gta6-sr-only" role="status" data-gta6-sr></p>
+  </div>
+
+  <button type="button" class="gta6-strip__dismiss" data-gta6-dismiss aria-label="Hide the <%= countdown.title %> countdown">&times;</button>
+
+  <span class="gta6-strip__horizon" aria-hidden="true"></span>
+</aside>
+<script src="/static/js/countdown.js?v=2"></script>
+<% } %>


### PR DESCRIPTION
Adds the web half of the GTA 6 launch countdown. Pairs with Linesmerrill/police-cad-api#187, which supplies the date, and the mobile card already on `production`.

## Where it lands

- **Landing page** — a strip between the hero and the stats band. `components/Gta6Countdown.tsx`, fed by a new `/api/countdown` proxy route so the API token never reaches the browser.
- **`/communities`** — the same strip in the existing promo slot, where visitors already arrive in discovery mode. Server-injected by the Express route.

I skipped `community-dashboard.ejs` even though it was the first candidate: it is still legacy Bootstrap 3 on a light theme, and it is a low-traffic community picker.

## Why the date is not a constant

A slipped launch gets fixed with one Mongo update and reaches both surfaces within five minutes. Both entry points cache for that long and fall back to a baked-in constant, so a slow or failing API degrades the strip rather than the page.

## Local midnight, not a converted instant

Console storefronts list GTA 6 at **local midnight in every market** rather than one synchronized worldwide moment. Converting a single UTC instant to local time would read zero roughly 13 hours after a New Zealand player could already play, and about 16 hours before a Los Angeles player could. So the target is midnight on `launchDate` in the visitor own timezone, and everybody timer reaches zero when their region unlocks. A `mode` field flips it to a fixed instant if a synchronized unlock is ever announced.

## Retirement

An "out now" state for `postLaunchHours`, then the strip removes itself. Without that a passed countdown becomes a negative timer, or dead UI nobody remembers to take down.

## Design

"Sunset strip" — the strip is the horizon. A hairline gradient rule runs its full width with a slatted sun bleeding up from behind it and the numerals sitting on top; the field stays near-black and all the colour is light rather than fill. It evokes the palette without using any Rockstar artwork or marks.

Accessibility: the ticking digits are `aria-hidden` with a status summary that updates once a minute rather than once a second, and every animation is dropped under `prefers-reduced-motion`.

## On the duplicated rules

The target rules exist three times — `lib/countdown.ts`, `public/js/countdown.js`, and the mobile app `utils/countdown.js` — because the three runtimes cannot share a module (`public/js` has no build step). Each file cross-references the others; the mobile copy carries the unit tests. The stylesheet **is** genuinely shared: both web surfaces load it from `/static/css/gta6-countdown.css`.

## Verification

`tsc --noEmit` and `next lint` both clean. Rendered against the local dev server at 1280px and 390px and captured both, plus the `/communities` inset variant; no console errors on either page. Confirmed the fallback path works end to end — the deployed API does not have the endpoint yet, so every screenshot here is the fallback branch doing its job.

Merge the API PR first. Nothing breaks if that order slips, because of the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)