### PR TITLE
Give "you can remove the code" one place people actually see

### DIFF
--- a/app/content-creators/me/VerificationPanel.tsx
+++ b/app/content-creators/me/VerificationPanel.tsx
@@ -266,25 +266,19 @@ function derivePanelState(
   }
 
   if (allOwned) {
-    const removal = codeRemovalSentence(platforms);
     return {
       tone: 'good',
       headline: platforms.length === 1 ? 'Channel verified' : 'All channels verified',
-      sub: `Nothing left for you to do. Your application is with our team.${
-        removal ? ` ${removal}` : ''
-      }`,
+      sub: 'Nothing left for you to do. Your application is with our team.',
     };
   }
 
   if (someOwned) {
     const left = platforms.filter((p) => !ownershipProven(p)).length;
-    const removal = codeRemovalSentence(platforms);
     return {
       tone: 'neutral',
       headline: `${left} channel${left === 1 ? '' : 's'} left to verify`,
-      sub: `Add the code to the remaining channel${left === 1 ? '' : 's'} and press Check.${
-        removal ? ` ${removal}` : ''
-      }`,
+      sub: `Add the code to the remaining channel${left === 1 ? '' : 's'} and press Check.`,
     };
   }
 
@@ -321,6 +315,12 @@ export default function VerificationPanel({
   const [expanded, setExpanded] = useState(false);
 
   const state = derivePanelState(platforms, checks, minFollowers);
+  // Used to be a trailing clause on the sub-line above, which meant it appeared
+  // exactly when the panel folds itself away and nobody read it: creators were
+  // leaving the code in their description long after it had done its job. It is
+  // its own line now, and it is rendered outside the header so the collapsed
+  // state still carries it.
+  const removal = codeRemovalSentence(platforms);
   const tone = TONE[state.tone];
   const qualifies = applicationQualifies(platforms, minFollowers);
   const allSettled =
@@ -394,6 +394,15 @@ export default function VerificationPanel({
           margin-bottom: 24px;
         }
         .vp-head { margin-bottom: 18px; }
+        .vp-code-out {
+          display: flex; align-items: flex-start; gap: 10px;
+          background: rgba(74, 222, 128, 0.07);
+          border: 1px solid rgba(74, 222, 128, 0.22);
+          border-radius: 10px; padding: 12px 14px; margin-bottom: 18px;
+        }
+        .vp-code-out svg { width: 18px; height: 18px; color: #4ade80; flex-shrink: 0; margin-top: 1px; }
+        .vp-code-out p { margin: 0; color: #e5e7eb; font-size: 14px; line-height: 1.55; }
+        .vp-code-out strong { color: #fff; }
         .vp-hide {
           margin-top: 10px; background: transparent; border: none; padding: 0;
           color: rgba(255,255,255,0.45); font-size: 13px; font-weight: 600;
@@ -506,6 +515,16 @@ export default function VerificationPanel({
           {allSettled && (
             <button className="vp-hide" onClick={() => setExpanded(false)}>Hide details</button>
           )}
+        </div>
+      )}
+
+      {removal && (
+        <div className="vp-code-out">
+          <CheckCircleIcon />
+          <p>
+            <strong>Verified.</strong> {removal} We have everything we need from it, and nothing
+            reads it again.
+          </p>
         </div>
       )}
 

--- a/app/content-creators/me/page.tsx
+++ b/app/content-creators/me/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import Navbar from '@/components/Navbar';
 import Footer from '@/components/Footer';
-import VerificationPanel, { codeRemovalSentence, DEFAULT_MIN_FOLLOWERS } from './VerificationPanel';
+import VerificationPanel, { DEFAULT_MIN_FOLLOWERS } from './VerificationPanel';
 import ProfileSetupChecklist from './ProfileSetupChecklist';
 import ApplicationProgress, { Stage } from './ApplicationProgress';
 import {
@@ -314,16 +314,16 @@ function buildStages(app: Application): Stage[] {
   // is coming — showing one would just be a countdown to a foregone answer.
   if (!belowMinimum) {
     const inReview = allVerified && !failed;
-    // "Nothing for you to do" is true but wasted: the one thing they can now do
-    // is undo the edit we asked them to make. Only ever say it about a platform
-    // we read through an API — a TikTok code stays until a human has seen it.
-    const removal = codeRemovalSentence(platforms);
+    // The "you can take the code out" line used to be tacked onto the end of
+    // this sentence as well as the verification panel's. Two trailing clauses
+    // in two paragraphs, and creators still left the code in place for weeks.
+    // It has one home now: the callout in VerificationPanel, which renders
+    // under the same conditions as this timeline and sits next to the code
+    // itself.
     stages.push({
       title: 'Review by our team',
       detail: inReview
-        ? `A member of our team is reviewing your application. This usually takes 3 to 5 business days.${
-            removal ? ` ${removal} We already have what we need.` : ' There is nothing for you to do in the meantime.'
-          }`
+        ? 'A member of our team is reviewing your application. This usually takes 3 to 5 business days. There is nothing for you to do in the meantime.'
         : 'Once your channels are verified, a member of our team reviews your application. This usually takes 3 to 5 business days.',
       state: inReview ? 'active' : 'upcoming',
     });


### PR DESCRIPTION
## The problem

An approved creator's YouTube description still opened with `LPC-VERIFY-BESH69`
weeks after we had read it.

The dashboard already said the code could come out. **In two separate places.**
Neither landed, and looking at where they were, that is not surprising:

1. **`VerificationPanel`** put it at the end of its sub-line — and that panel
   collapses to a single row the moment every channel is verified
   (`collapsed = allSettled && !expanded`). So the sentence appeared at exactly
   the moment the panel folded itself away.
2. **The progress timeline** tacked it onto the end of the "Review by our team"
   paragraph.

Two trailing clauses in two paragraphs, both easy to skim straight past.

## What changed

It has one home now: a callout in `VerificationPanel`, rendered **outside** the
header block so the collapsed state carries it too, sitting right next to the
code it is talking about.

> **Verified.** You can take the code back out of your YouTube description now.
> We have everything we need from it, and nothing reads it again.

The timeline stage goes back to plain "there is nothing for you to do in the
meantime". It renders under the same status conditions as the panel, and
`codeRemovalSentence` only returns text when there is a verified removable
platform — which implies the panel is rendered too — so saying it once loses
nothing.

## Not a behaviour change

Which platforms qualify is untouched. `REMOVABLE_CODE_PLATFORMS` is still
YouTube and Twitch only: TikTok's code stays put because a human confirms that
one by eye during review. And it is safe to say at all because
`screenAndPersist` skips any platform where `IsVerified()` is true and never
re-fetches it, and the sweep only looks at `submitted` and `under_review`
applications.

## Verification

- `tsc --noEmit` clean, `next lint` clean — no new warnings on either file
  (`VerificationPanel.tsx` reports none at all).
- The callout was rendered in a browser at 820px and 390px, in the collapsed
  state, the expanded state, and with two channels, using the component's own
  `<style>` block lifted verbatim so the preview cannot drift from the source.

Paired with Linesmerrill/police-cad-api#188, which adds the same reminder to the
approval, rejection and follower-minimum emails — the surface that reaches an
already-approved creator, who has no reason to open this dashboard again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
