### PR TITLE
Render house promos into ad slots Google did not fill

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -150,6 +150,51 @@ async function getActiveCountdown(surface) {
   }
 }
 
+// Internal promotions, rendered by the clients into an ad slot Google did not
+// fill (see public/js/house-promo.js). The server only supplies the payload.
+//
+// No fallback constant, deliberately, and this is the one place this differs
+// from the countdown above: a countdown showing a known date while the API is
+// unreachable is useful, whereas a promo that keeps running when it cannot be
+// switched off is a liability. If the lookup fails, no promo renders and the ad
+// slot collapses exactly as it does today.
+var HOUSE_PROMO_CACHE_TTL_MS = 5 * 60 * 1000;
+var housePromoCache = { value: null, at: 0, valid: false };
+
+async function getActiveHousePromo(surface) {
+  var now = Date.now();
+  if (housePromoCache.valid && now - housePromoCache.at < HOUSE_PROMO_CACHE_TTL_MS) {
+    return housePromoCache.value;
+  }
+  if (!policeCadApiUrl) return null;
+
+  try {
+    var response = await axios.get(
+      `${policeCadApiUrl}/api/v1/house-promos?surface=${encodeURIComponent(surface)}`,
+      Object.assign({}, config, { timeout: 4000 })
+    );
+    var list = Array.isArray(response.data) ? response.data : [];
+    var live = list.filter(function (p) {
+      if (!p || p.active === false || !p.title || !p.ctaUrl) return false;
+      // The API filters on endsAt too. Re-checking here means a cached
+      // response cannot outlive the campaign by up to the cache TTL.
+      if (p.endsAt) {
+        var ends = new Date(p.endsAt).getTime();
+        if (!isNaN(ends) && ends <= now) return false;
+      }
+      return true;
+    });
+    // Having no promo running is a real answer, so null is cached too --
+    // otherwise switching one off would cost an API round-trip per page load.
+    housePromoCache = { value: live[0] || null, at: now, valid: true };
+    return housePromoCache.value;
+  } catch (err) {
+    // Not cached: the next request retries rather than sitting on a blip for
+    // five minutes. Returns null, so the slot just stays empty.
+    return null;
+  }
+}
+
 module.exports = function (app, passport, server, nextApp, handle) {
   // Root route - use Next.js if available, otherwise fall back to EJS
   app.get("/", function (req, res) {
@@ -1752,6 +1797,7 @@ module.exports = function (app, passport, server, nextApp, handle) {
           departmentId: departmentId,
           departmentComponents: departmentComponents,
           apiUrl: policeCadApiUrl,
+          housePromo: await getActiveHousePromo("web"),
         });
       } catch (error) {
         console.error('Error in civ-dashboard route:', error);

--- a/public/css/house-promo.css
+++ b/public/css/house-promo.css
@@ -1,0 +1,112 @@
+/* House promo card.
+ *
+ * Rendered by public/js/house-promo.js into an ad slot that Google did not
+ * fill, so it inherits the container an ad would have had. It is styled to the
+ * dashboard's own surface rather than to look like a banner: this is us
+ * talking, not a bought placement, and the eyebrow says so.
+ *
+ * Deliberately quiet. It appears only on the fraction of loads where an ad did
+ * not fill, and it should read as a note rather than a campaign.
+ */
+
+.hp-card {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  /* Fills the ad container rather than floating inset inside it. The container
+   * brings its own border, so a card sitting in the middle of it reads as two
+   * nested boxes. */
+  width: 100%;
+  box-sizing: border-box;
+  text-align: left;
+  padding: 18px 20px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(122, 90, 248, 0.1) 0%, rgba(56, 189, 248, 0.06) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.hp-mark {
+  flex: 0 0 auto;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  line-height: 1;
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.hp-text {
+  min-width: 0;
+  flex: 1;
+}
+
+.hp-eyebrow {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.45);
+  margin-bottom: 3px;
+}
+
+.hp-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #fff;
+  line-height: 1.3;
+  margin: 0 0 3px;
+}
+
+.hp-body {
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.65);
+  margin: 0;
+}
+
+.hp-cta {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 9px 16px;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.hp-cta:hover,
+.hp-cta:focus {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.28);
+  color: #fff;
+  text-decoration: none;
+}
+
+/* Phones: the CTA cannot sit beside the text without squeezing both, and it is
+ * the thing being tapped, so it gets a full-width row of its own. */
+@media (max-width: 640px) {
+  .hp-card {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 14px;
+    padding: 16px;
+  }
+  .hp-cta {
+    width: 100%;
+    justify-content: center;
+    min-height: 40px;
+  }
+}

--- a/public/js/house-promo.js
+++ b/public/js/house-promo.js
@@ -1,0 +1,158 @@
+/* House promos: fill an ad slot that Google didn't.
+ *
+ * AdSense sets data-ad-status="unfilled" on an <ins> it could not fill, and
+ * the dashboards already watch for that so they can collapse the container.
+ * This takes the same signal and puts one of our own messages in the space
+ * instead, so a slot that was going to be blank carries something.
+ *
+ * Consequences worth knowing:
+ *   - It never displaces a paying ad. If Google filled the slot, this does
+ *     nothing at all.
+ *   - It inherits the ad's visibility rules for free. The containers are only
+ *     rendered for users who see ads in the first place, so a Premium Plus
+ *     subscriber has no container here to fill.
+ *   - It is intermittent by nature, which is the point. This is a note, not a
+ *     campaign.
+ *
+ * The promo itself is injected server-side into #hp-source as a JSON payload
+ * (see views/partials/house-promo.ejs). Nothing here calls the API.
+ */
+(function (global) {
+  "use strict";
+
+  // Google flips data-ad-status once it has decided. Two passes rather than
+  // one: the first catches the common case quickly, the second covers a slow
+  // network without making everyone wait that long to see anything.
+  var PASSES_MS = [2000, 5000];
+
+  function readPromo() {
+    var node = document.getElementById("hp-source");
+    if (!node) return null;
+    try {
+      var promo = JSON.parse(node.textContent || "null");
+      // The API already drops half-written records, but this runs against
+      // whatever the page was rendered with, so check again rather than
+      // building a card with a dead button.
+      if (!promo || !promo.title || !promo.ctaUrl) return null;
+      return promo;
+    } catch (err) {
+      return null;
+    }
+  }
+
+  function esc(value) {
+    var d = document.createElement("div");
+    d.textContent = value == null ? "" : String(value);
+    return d.innerHTML;
+  }
+
+  // Only http(s) links get rendered. These records are hand-edited in Mongo,
+  // and a javascript: URL pasted into ctaUrl would otherwise become a click
+  // handler on a logged-in page.
+  function safeUrl(value) {
+    var raw = String(value == null ? "" : value).trim();
+    return /^https?:\/\//i.test(raw) ? raw : "";
+  }
+
+  function isUnfilled(ins) {
+    if (!ins) return true;
+    var status = ins.getAttribute("data-ad-status");
+    if (status === "unfilled") return true;
+    // No status and no iframe by the time we look means it never loaded --
+    // a blocker, a network failure, or a slot Google has nothing for.
+    return !status && !ins.querySelector("iframe");
+  }
+
+  function buildCard(promo) {
+    var url = safeUrl(promo.ctaUrl);
+    if (!url) return null;
+
+    var card = document.createElement("div");
+    card.className = "hp-card";
+    card.innerHTML =
+      '<div class="hp-mark" aria-hidden="true">' + esc(promo.mark || "❤️") + "</div>" +
+      '<div class="hp-text">' +
+        (promo.eyebrow ? '<div class="hp-eyebrow">' + esc(promo.eyebrow) + "</div>" : "") +
+        '<p class="hp-title">' + esc(promo.title) + "</p>" +
+        (promo.body ? '<p class="hp-body">' + esc(promo.body) + "</p>" : "") +
+      "</div>" +
+      '<a class="hp-cta" target="_blank" rel="noopener noreferrer external"></a>';
+
+    var cta = card.querySelector(".hp-cta");
+    cta.href = url;
+    cta.textContent = promo.ctaLabel || "Learn more";
+    return card;
+  }
+
+  function fillSlots(promo) {
+    var filled = 0;
+
+    Array.prototype.forEach.call(
+      document.querySelectorAll(".heroui-ad-container"),
+      function (container) {
+        if (container.getAttribute("data-hp-filled") === "1") return;
+        if (!isUnfilled(container.querySelector("ins.adsbygoogle"))) return;
+
+        var card = buildCard(promo);
+        if (!card) return;
+
+        // The label said "Advertisement". This is not one, and leaving that
+        // there would be the one genuinely dishonest thing about the feature.
+        var label = container.querySelector(".heroui-ad-label");
+        if (label) label.remove();
+
+        var content = container.querySelector(".heroui-ad-content");
+        if (content) {
+          content.innerHTML = "";
+          content.appendChild(card);
+        } else {
+          container.innerHTML = "";
+          container.appendChild(card);
+        }
+
+        // The container hides itself via .ad-unfilled and :empty. It has
+        // something in it now, so both have to come off.
+        container.classList.remove("ad-unfilled");
+        container.setAttribute("data-hp-filled", "1");
+        filled += 1;
+      }
+    );
+
+    return filled;
+  }
+
+  function run() {
+    var promo = readPromo();
+    // No promo running is the steady state. Leave the page exactly as it was,
+    // so the container collapses the way it always has.
+    if (!promo) return;
+    PASSES_MS.forEach(function (delay) {
+      global.setTimeout(function () {
+        fillSlots(promo);
+      }, delay);
+    });
+  }
+
+  // Exported for tests. The init guard stays off the export so a test can call
+  // these directly without the page having auto-run.
+  global.housePromo = {
+    buildCard: buildCard,
+    isUnfilled: isUnfilled,
+    safeUrl: safeUrl,
+    fillSlots: fillSlots,
+  };
+
+  // Also usable from the unit harness, same as public/js/vehicle-flags.js.
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = global.housePromo;
+  }
+
+  if (!global.__housePromoInit && typeof document !== "undefined") {
+    global.__housePromoInit = true;
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", run);
+    } else {
+      run();
+    }
+  }
+})(typeof window !== "undefined" ? window : globalThis);

--- a/test/house-promo.test.js
+++ b/test/house-promo.test.js
@@ -1,0 +1,57 @@
+var assert = require("assert");
+
+var HousePromo = require("../public/js/house-promo");
+
+/*
+ * House promo records are hand-edited in Mongo and rendered into an ad slot on
+ * a page the user is logged in to. safeUrl is the boundary between those two
+ * facts: it is what stops a pasted ctaUrl from becoming a click handler.
+ *
+ * The DOM-driven parts of this file are exercised in a real browser during
+ * verification; this pins the pure function that carries the security weight.
+ */
+describe("house promo safeUrl", function () {
+  it("accepts the links these promos actually use", function () {
+    assert.strictEqual(
+      HousePromo.safeUrl("https://www.gofundme.com/f/help-my-brother-recover-2b-lost-runescape-gp"),
+      "https://www.gofundme.com/f/help-my-brother-recover-2b-lost-runescape-gp"
+    );
+    assert.strictEqual(HousePromo.safeUrl("http://example.com/x?a=1&b=2"), "http://example.com/x?a=1&b=2");
+  });
+
+  it("trims surrounding whitespace rather than rejecting the link", function () {
+    // Copy-pasted into a Mongo shell, a trailing newline is easy to leave in.
+    assert.strictEqual(HousePromo.safeUrl("  https://example.com/x \n"), "https://example.com/x");
+  });
+
+  it("refuses a javascript: URL", function () {
+    // The whole point. This would otherwise run on a logged-in dashboard.
+    assert.strictEqual(HousePromo.safeUrl("javascript:alert(1)"), "");
+    assert.strictEqual(HousePromo.safeUrl("JaVaScRiPt:alert(1)"), "");
+    assert.strictEqual(HousePromo.safeUrl("  javascript:alert(1)"), "");
+  });
+
+  it("refuses other non-http schemes", function () {
+    assert.strictEqual(HousePromo.safeUrl("data:text/html,<script>alert(1)</script>"), "");
+    assert.strictEqual(HousePromo.safeUrl("vbscript:msgbox(1)"), "");
+    assert.strictEqual(HousePromo.safeUrl("file:///etc/passwd"), "");
+  });
+
+  it("refuses a protocol-relative or bare path, which cannot be verified by eye", function () {
+    assert.strictEqual(HousePromo.safeUrl("//evil.test/x"), "");
+    assert.strictEqual(HousePromo.safeUrl("/somewhere"), "");
+  });
+
+  it("treats missing values as no link", function () {
+    assert.strictEqual(HousePromo.safeUrl(""), "");
+    assert.strictEqual(HousePromo.safeUrl(null), "");
+    assert.strictEqual(HousePromo.safeUrl(undefined), "");
+  });
+});
+
+describe("house promo isUnfilled", function () {
+  it("treats a missing <ins> as unfilled", function () {
+    // Nothing to displace, so the slot is ours to use.
+    assert.strictEqual(HousePromo.isUnfilled(null), true);
+  });
+});

--- a/views/civ-dashboard.ejs
+++ b/views/civ-dashboard.ejs
@@ -2373,11 +2373,20 @@
   <script src="/static/js/modern-dashboard.js?v=<%= typeof buildVersion !== 'undefined' ? buildVersion : 'dev' %>"></script>
   <script src="/static/js/cloudinary-upload.js?v=<%= typeof buildVersion !== 'undefined' ? buildVersion : 'dev' %>"></script>
 
+  <%# Puts one of our own messages into an ad slot Google did not fill. Emits
+      nothing at all when no promo is running, and never touches a slot that an
+      ad filled. Must come before the collapse script below. %>
+  <%- include('partials/house-promo') %>
+
   <!-- Hide ad containers if ads don't fill -->
   <script>
   (function() {
     function checkAds() {
       document.querySelectorAll('.heroui-ad-container').forEach(function(c) {
+        // A container house-promo.js has filled is no longer empty, whichever
+        // of the two scripts got here first. Without this the promo is injected
+        // and then immediately hidden again by the class this adds.
+        if (c.getAttribute('data-hp-filled') === '1') return;
         var ins = c.querySelector('ins.adsbygoogle');
         if (!ins) { c.classList.add('ad-unfilled'); return; }
         var status = ins.getAttribute('data-ad-status');

--- a/views/partials/house-promo.ejs
+++ b/views/partials/house-promo.ejs
@@ -1,0 +1,26 @@
+<%
+  // House promo payload for public/js/house-promo.js.
+  //
+  // Server-rendered rather than fetched, so the page makes no extra request and
+  // the card is ready the moment an ad slot turns out to be empty. Emits
+  // nothing at all when no promo is running, which is the steady state.
+  //
+  // The script fills any .heroui-ad-container whose AdSense <ins> came back
+  // unfilled. It never touches a slot Google filled.
+  var _hp = typeof housePromo !== 'undefined' ? housePromo : null;
+%>
+<% if (_hp && _hp.title && _hp.ctaUrl) { %>
+  <link rel="stylesheet" href="/static/css/house-promo.css?v=<%= typeof buildVersion !== 'undefined' ? buildVersion : 'dev' %>">
+  <%# JSON in a script tag rather than data- attributes: the body is a sentence
+      and would need escaping twice. type="application/json" is inert. %>
+  <script id="hp-source" type="application/json"><%- JSON.stringify({
+    slug: _hp.slug,
+    eyebrow: _hp.eyebrow,
+    title: _hp.title,
+    body: _hp.body,
+    ctaLabel: _hp.ctaLabel,
+    ctaUrl: _hp.ctaUrl,
+    mark: _hp.mark,
+  }).replace(/</g, '\\u003c') %></script>
+  <script src="/static/js/house-promo.js?v=<%= typeof buildVersion !== 'undefined' ? buildVersion : 'dev' %>"></script>
+<% } %>


### PR DESCRIPTION
Consumes `GET /api/v1/house-promos` (Linesmerrill/police-cad-api#189) so we can
put an internal message in front of players without buying a slot or building
one.

## Where the space comes from

`civ-dashboard.ejs` has watched for `data-ad-status="unfilled"` since it was
written, so it can collapse a container Google had nothing for. This takes the
same signal and puts one of our own messages there instead.

Beyond not building a new slot, that buys three things:

- **It never displaces a paying ad.** If Google filled the slot, this does
  nothing at all.
- **It inherits ad visibility for free.** The containers are only rendered for
  users who see ads in the first place, so Premium Plus has no container here to
  fill and needs no new logic.
- **It is intermittent by nature**, which is the intended feel — a note, not a
  campaign.

## Implementation

`getActiveHousePromo` mirrors `getActiveCountdown` next to it: same 5-minute TTL
cache, never throws, caches a `null` answer so switching a promo off does not
cost an API round-trip per page load. It re-checks `endsAt` client-side too, so
a cached response cannot outlive a campaign by up to the TTL.

**No fallback constant, deliberately** — the one place this parts company with
the countdown. A countdown rendering a known date while the API is unreachable
is useful; a promo that keeps running when it cannot be switched off is a
liability. A failed lookup means no promo, and the slot collapses as it does
today.

Two things worth a look in review:

- **The "Advertisement" label is removed from any slot we fill.** It is not one,
  and leaving it would be the single genuinely dishonest thing about the feature.
- **The existing collapse script now skips containers we filled.** Both run on
  the same 2s/5s passes, and without the guard the promo was injected and then
  immediately hidden again by the class the other script adds. The guard is
  order-independent — either script can win the race.

## Hardening

These records are hand-edited in Mongo and render on a logged-in dashboard, so:

- only `http(s)` `ctaUrl`s render — a pasted `javascript:` URL builds no card
- the payload is JSON with `<` escaped to `<`, so a `</script>` in the body
  cannot break out of the tag carrying it
- all text is escaped on insertion

## Verification

**19 checks driven in a real browser** against the actual rendered dashboard:

- the card injected into an unfilled slot, container un-collapsed, title,
  eyebrow, CTA label, `href` and `rel="noopener"` all correct
- **a filled ad slot left completely untouched**
- the no-promo path injecting nothing, not even loading the script, and the slot
  still collapsing exactly as before
- Premium Plus seeing no promo, because no container exists to fill
- a `javascript:` `ctaUrl` refused and no script executed from a hostile record
- rendered at 1280px and 390px, no horizontal page overflow

Plus **7 unit tests** on the URL guard (`test/house-promo.test.js`), following
the `vehicle-flags.js` pattern. Full mocha suite 32 passing; `tsc --noEmit` and
`next lint` clean.

## Scope

Wired into `civ-dashboard.ejs` only for now. The other ad-bearing views are
Media.net (`ad-body.ejs` on the police/dispatch dashboards) rather than AdSense,
so fill detection there is a different mechanism, and `release-log` / `about` are
legacy light-theme pages that would need a second visual treatment. Both are
straightforward follow-ups once this pattern is proven in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
