### PR TITLE
Restore AdSense on the Next.js pages (and 9 EJS pages that never had it)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import './globals.css';
 import Script from 'next/script';
+import AdSense from '@/components/AdSense';
 
 export const metadata: Metadata = {
   title: 'LPC - Lines Police CAD',
@@ -45,6 +46,10 @@ export default function RootLayout({
             gtag('config', 'G-1L40PLRXWM');
           `}
         </Script>
+        {/* The AdSense base tag. Every page migrated from EJS to Next.js lost
+            its ads because nothing here replaced views/ad-header.ejs. It sits
+            in the root layout so a new page cannot miss it the same way. */}
+        <AdSense />
         {children}
       </body>
     </html>

--- a/app/routes.js
+++ b/app/routes.js
@@ -1375,27 +1375,23 @@ module.exports = function (app, passport, server, nextApp, handle) {
   //   res.render("penal-code");
   // });
 
-  app.get("/ads.txt", (req, res) => {
-    res.set("Content-Type", "text");
-    let message = "google.com, pub-3842696805773142, DIRECT, f08c47fec0942fa0";
-    return res.send(
-      new Buffer.alloc(
-        message.length,
-        "google.com, pub-3842696805773142, DIRECT, f08c47fec0942fa0"
-      )
-    );
-  });
+  // ads.txt / app-ads.txt. Google's crawler wants text/plain; the header here
+  // used to be the bare string "text", which is not a valid media type.
+  //
+  // The body was also built with Buffer.alloc(message.length, message), which
+  // only produced the right output because the fill string happened to be
+  // exactly as long as the buffer. Change the publisher ID to one of a
+  // different length and it would have silently truncated the line, which is
+  // the kind of thing that shows up as an AdSense earnings warning rather than
+  // as an error anyone would see.
+  const ADS_TXT = "google.com, pub-3842696805773142, DIRECT, f08c47fec0942fa0\n";
 
-  app.get("/app-ads.txt", (req, res) => {
-    res.set("Content-Type", "text");
-    let message = "google.com, pub-3842696805773142, DIRECT, f08c47fec0942fa0";
-    return res.send(
-      new Buffer.alloc(
-        message.length,
-        "google.com, pub-3842696805773142, DIRECT, f08c47fec0942fa0"
-      )
-    );
-  });
+  const serveAdsTxt = (req, res) => {
+    res.type("text/plain").send(ADS_TXT);
+  };
+
+  app.get("/ads.txt", serveAdsTxt);
+  app.get("/app-ads.txt", serveAdsTxt);
 
   // Login page is now handled by Next.js at app/login/page.tsx
   

--- a/components/AdSense.tsx
+++ b/components/AdSense.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Script from 'next/script';
+
+/**
+ * Loads the Google AdSense base tag on Next.js pages.
+ *
+ * Every page migrated from EJS to Next.js silently lost its ads: the EJS views
+ * pull the tag in through views/ad-header.ejs, and nothing in the App Router
+ * ever replaced it. That included the home page. This is the replacement, and
+ * it belongs in the root layout so a future page cannot miss it the same way.
+ *
+ * Auto ads mean the tag is all that is needed -- placement is decided in the
+ * AdSense dashboard rather than by markup on the page, so there is no per-page
+ * work to keep in step.
+ */
+
+const AD_CLIENT = 'ca-pub-3842696805773142';
+
+// Mirrors _skipAdsense in views/ad-header.ejs. Paying for Premium buys fewer
+// ads, and that promise has to hold on the Next.js pages too -- otherwise
+// restoring ads here quietly takes something away from subscribers.
+function paysForFewerAds(user: any): boolean {
+  const sub = user?.subscription;
+  if (!sub?.active) return false;
+  return sub.plan === 'premium' || sub.plan === 'premium_plus';
+}
+
+export default function AdSense() {
+  // Three states, and the distinction matters: null means "still asking", and
+  // loading the tag then would show ads to a subscriber for the moment before
+  // the answer arrives.
+  const [allowed, setAllowed] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    fetch('/api/user/current', { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (mounted) setAllowed(!paysForFewerAds(data?.user));
+      })
+      .catch(() => {
+        // Logged out, or the lookup failed. Both are the common case for the
+        // pages that carry the most ad traffic, so show ads rather than
+        // withholding them over a failed request.
+        if (mounted) setAllowed(true);
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  if (!allowed) return null;
+
+  return (
+    <Script
+      id="adsbygoogle-init"
+      src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${AD_CLIENT}`}
+      strategy="afterInteractive"
+      crossOrigin="anonymous"
+    />
+  );
+}

--- a/views/community-forms.ejs
+++ b/views/community-forms.ejs
@@ -4,6 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Forms - Lines Police CAD</title>
+  <%# AdSense base tag. Auto ads place the units, so this is all these
+      pages need. It also carries the Premium/Premium Plus skip, so the
+      gating stays in one file. %>
+  <%- include('ad-header') %>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
   <link rel="shortcut icon" type="image/ico" href="/static/images/favicon.ico" />
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet" />

--- a/views/community-map.ejs
+++ b/views/community-map.ejs
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Community Map - <%= community.community.name %></title>
+  <%# AdSense base tag. Auto ads place the units, so this is all these
+      pages need. It also carries the Premium/Premium Plus skip, so the
+      gating stays in one file. %>
+  <%- include('ad-header') %>
   <link rel="shortcut icon" type="image/ico" href="/static/images/favicon.ico" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">

--- a/views/court-cases.ejs
+++ b/views/court-cases.ejs
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Court Cases - Lines Police CAD</title>
+  <%# AdSense base tag. Auto ads place the units, so this is all these
+      pages need. It also carries the Premium/Premium Plus skip, so the
+      gating stays in one file. %>
+  <%- include('ad-header') %>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
   <link rel="shortcut icon" type="image/ico" href="static/images/favicon.ico">
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">

--- a/views/court-session.ejs
+++ b/views/court-session.ejs
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Court Session - Lines Police CAD</title>
+  <%# AdSense base tag. Auto ads place the units, so this is all these
+      pages need. It also carries the Premium/Premium Plus skip, so the
+      gating stays in one file. %>
+  <%- include('ad-header') %>
   <link rel="shortcut icon" type="image/ico" href="/static/images/favicon.ico" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
   <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/views/economy-settings.ejs
+++ b/views/economy-settings.ejs
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Economy Settings - Lines Police CAD</title>
+  <%# AdSense base tag. Auto ads place the units, so this is all these
+      pages need. It also carries the Premium/Premium Plus skip, so the
+      gating stays in one file. %>
+  <%- include('ad-header') %>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
   <link rel="shortcut icon" type="image/ico" href="static/images/favicon.ico">
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">

--- a/views/help-tutorial.ejs
+++ b/views/help-tutorial.ejs
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Help & Tutorials - Lines Police CAD</title>
+  <%# AdSense base tag. Auto ads place the units, so this is all these
+      pages need. It also carries the Premium/Premium Plus skip, so the
+      gating stays in one file. %>
+  <%- include('ad-header') %>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
   <link rel="shortcut icon" type="image/ico" href="static/images/favicon.ico">
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">

--- a/views/inbox.ejs
+++ b/views/inbox.ejs
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Inbox - Lines Police CAD</title>
+  <%# AdSense base tag. Auto ads place the units, so this is all these
+      pages need. It also carries the Premium/Premium Plus skip, so the
+      gating stays in one file. %>
+  <%- include('ad-header') %>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
   <link rel="shortcut icon" type="image/ico" href="static/images/favicon.ico">
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">

--- a/views/reports-list.ejs
+++ b/views/reports-list.ejs
@@ -4,6 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Reports - Lines Police CAD</title>
+  <%# AdSense base tag. Auto ads place the units, so this is all these
+      pages need. It also carries the Premium/Premium Plus skip, so the
+      gating stays in one file. %>
+  <%- include('ad-header') %>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
   <link rel="shortcut icon" type="image/ico" href="/static/images/favicon.ico" />
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet" />

--- a/views/wallet.ejs
+++ b/views/wallet.ejs
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Wallet - Lines Police CAD</title>
+  <%# AdSense base tag. Auto ads place the units, so this is all these
+      pages need. It also carries the Premium/Premium Plus skip, so the
+      gating stays in one file. %>
+  <%- include('ad-header') %>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
   <link rel="shortcut icon" type="image/ico" href="static/images/favicon.ico">
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## The cause of the revenue drop

Ad revenue fell from $1-2k/month to about $300. It is structural, not market:
**every page migrated from EJS to Next.js silently lost its ads.**

`views/ad-header.ejs` carries the AdSense base tag. Nothing in the App Router
ever replaced it — `app/layout.tsx` loads Google Analytics and stops there. So
all 30 Next.js pages serve zero ads. Confirmed against production:

```
/ (home)            ** NO **  Next.js
/penal-code         ** NO **  Next.js
/faq                ** NO **  Next.js
/about-us           ** NO **  Next.js
/contact-us         ** NO **  Next.js
/pricing            ** NO **  Next.js
/privacy-policy     ** NO **  Next.js
/discord-bot        ** NO **  Next.js
/content-creators   ** NO **  Next.js
/feature-requests   ** NO **  Next.js
/communities        YES       EJS
/release-log        YES       EJS
/rules              YES       EJS
```

The EJS views for those paths still exist and still include `ad-header`, so the
ads look present in the codebase. They are dead files — the Express routes are
commented out (`// app.get("/penal-code"...`) and Next.js serves them.

**The timeline matches the revenue:**

```
2025-12-29   home page     -> Next.js
2025-12-30   about-us, contact-us, privacy-policy
2026-01-21   faq
2026-01-23   content-creators
2026-01-28   pricing
2026-01-30   penal-code
```

The highest-traffic page stopped serving ads in late December; the rest followed
through January.

## Fixes

**1. `components/AdSense.tsx`, mounted in the root layout.** Auto ads means the
tag is all that is needed, so this covers all 30 pages and anything added later.

It mirrors `_skipAdsense` from `ad-header.ejs`: an active `premium` or
`premium_plus` subscriber loads no tag at all. That gate has to be here —
without it, restoring ads would quietly take something away from the people
paying not to see them. A logged-out or failed lookup shows ads, since that is
the common case on the pages carrying the most traffic.

**2. `include('ad-header')` on 9 live EJS pages that never had it:** `wallet`,
`court-cases`, `inbox`, `reports-list`, `community-map`, `help-tutorial`,
`court-session`, `economy-settings`, `community-forms`. These are in-CAD pages
players sit on during a session. Admin pages deliberately excluded.

**3. `ads.txt` / `app-ads.txt` served an invalid MIME type.** Live before this
PR:

```
content-type: text
```

`text` is not a valid media type; Google's crawler wants `text/plain`. The body
was also built with `Buffer.alloc(message.length, message)`, which only produced
the right output because the fill string happened to be exactly 58 bytes — a
publisher ID of a different length would have silently truncated the line.
**Worth checking the AdSense dashboard for an ads.txt warning**, since I cannot
tell from here whether Google was rejecting it. It was wrong either way.

## Verification

Driven in a browser against the dev server with `/api/user/current` stubbed per
case — **7/7**:

| page | user | result |
|---|---|---|
| `/`, `/faq`, `/pricing` | logged out | tag loads, correct `client=` |
| `/` | free | tag loads |
| `/` | premium | **skipped** |
| `/` | premium_plus | **skipped** |
| `/` | lapsed premium | tag loads |

All **9 EJS pages** render the tag for free users and skip it for both paid
tiers. Both `ads.txt` routes now answer `text/plain; charset=utf-8`.

`tsc --noEmit`, `next lint` and the mocha suite are clean. No CSP is blocking
anything, and the existing premium gating on the surviving EJS pages was already
correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
